### PR TITLE
Miscellaneous updates to fitting and other things

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install pip packages
         run: |
           conda run -n coffea-env pip install xgboost
-          conda run -n coffea-env pip install mt2
+          conda run -n coffea-env pip install mt2==1.2.0
           conda list -n coffea-env
 
       - name: Download root files

--- a/FITTING.md
+++ b/FITTING.md
@@ -6,15 +6,12 @@ This readme describes how to perform the statistical analysis on the histograms 
 
 The information in the histograms (produced by the processor) can be converted into datacards (to be fed to `combine`) via the `make_datacards.py` script.
 
-* Example of running over Run2 histograms, with data-driven background estimation (on by default) and systematics (`-s`) for the BDT bins (`--bdt`): 
+* Example of running over Run2 histograms with systematics (`-s`) for the BDT bins (`--bdt`). 
   ```
   python make_datacards.py histos/yourhist.pkl.gz --run run2 -s --bdt
   ```
 
-* Example of running over Run3 (which right now is just 2022) histograms: 
-  ```
-  python make_datacards.py histos/yourhisto.pkl.gz --run run3
-  ```
+Note that by default the code will include CR bins to handle background normalization via a simultaneous SR+CR fit, using the `rateParam` functionality in combine (described in the combine documentation [here](https://cms-analysis.github.io/HiggsAnalysis-CombinedLimit/latest/model_building_tutorial2024/model_building_exercise/#rate-parameters)). 
 
 ## Using combine to perform the statistical analysis 
 

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -32,11 +32,18 @@ SYSTS_SPECIAL_RUN3 = {
     "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["2022"]},
 }
 
+# Hard code the rateParam lines to put at the end of the card (for background normalization)
+RATE_PARAM_LINES = [
+    "ZZ_norm rateParam * ZZ 1 [0,5]",
+    "txZ_norm rateParam * ttZ 1 [0,5]",
+    "txZ_norm rateParam * tWZ 1 [0,5]",
+]
+
 
 ########### Writing the datacard ###########
 
 # Make the datacard for a given channel
-def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,out_dir="."):
+def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,extra_lines=None,out_dir="."):
 
     # Building blocks we'll need to build the card formatting
     bin_str = f"bin_{ch}"
@@ -122,6 +129,10 @@ def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,out_dir="."):
         else:
             f.write(line_break)
 
+        # Write any extra lines
+        if extra_lines is not None:
+            for extra_line in extra_lines:
+                f.write(f"{extra_line}\n")
 
 
 
@@ -357,7 +368,7 @@ def main():
     parser.add_argument("in_file_name",help="Either json file of yields or pickle file with scikit hists")
     parser.add_argument("--out-dir","-d",default="./cards_wwz4l",help="Output directory to write root and text datacard files to")
     parser.add_argument("-s","--do-nuisance",action="store_true",help="Include nuisance parameters")
-    parser.add_argument("--no-tf",action="store_true",help="Skip doing the data-driven background estimation")
+    parser.add_argument("--do-tf",action="store_true",help="Do the TF data-driven background estimation")
     parser.add_argument("--bdt",action="store_true",help="Use BDT SR bins")
     parser.add_argument("--unblind",action="store_true",help="If set, use real data, otherwise use asimov data")
     parser.add_argument('-u', "--run", default='run2', help = "Which years to process", choices=["run2","run3"])
@@ -366,7 +377,7 @@ def main():
     in_file = args.in_file_name
     out_dir = args.out_dir
     do_nuis = args.do_nuisance
-    skip_tf = args.no_tf
+    do_tf   = args.do_tf
     use_bdt_sr = args.bdt
     unblind = args.unblind
     run = args.run
@@ -440,21 +451,30 @@ def main():
         kappa_dict = add_stats_kappas(yld_dict_mc,kappa_dict,skip_procs=["ZZ","ttZ"])
 
     # Do the TF calculation
-    if not skip_tf:
+    if do_tf:
         yld_dict_mc, kappa_dict, gmn_dict = yt.do_tf(yld_dict_mc,yld_dict_data,kappa_dict,sg.BKG_TF_MAP)
 
 
     #### Make the cards for each channel ####
-    cat_lst = sg.CAT_LST_CB
+
+    # Get list of channels
+    cat_lst_cr = ["cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_of_3b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b", "cr_4l_btag_sf_offZ_met80_3b","cr_4l_sf"]
+    cat_lst_sr = sg.CAT_LST_CB
     if use_bdt_sr:
         if run == "run2":
-            cat_lst = sg.CAT_LST_BDT
+            cat_lst_sr = sg.CAT_LST_BDT
         elif run == "run3":
-            cat_lst = sg.CAT_LST_BDT_COARSE
+            cat_lst_sr = sg.CAT_LST_BDT_COARSE
         else:
             raise Exception("Unknown year")
+    cat_lst = cat_lst_sr + cat_lst_cr
     print(f"\nMaking cards for {cat_lst}. \nPutting in {out_dir}.")
+
+    # Loop over channels and make cards
     for ch in cat_lst:
+
+        # Use real data in CRs
+        if ch in cat_lst_cr: unblind = True
 
         # Get just the info we want to put in the card in str form
         rate_for_dc_ch = get_rate_for_dc(yld_dict_mc,yld_dict_data,ch,unblind)
@@ -465,7 +485,8 @@ def main():
         if do_nuis:
             kappa_for_dc_ch = get_kappa_for_dc(kappa_dict,ch)
             kappa_for_dc_ch.update(get_rate_systs(sg.PROC_LST)) # Append in the ones from rate json
-        if do_nuis and not skip_tf:
+        if do_nuis and do_tf and (ch not in cat_lst_cr):
+            # TF calculation not meaningful for CRs
             gmn_for_dc_ch = get_gmn_for_dc(gmn_dict[ch],proc_lst=sg.PROC_LST)
 
 
@@ -476,7 +497,8 @@ def main():
             rate_for_dc_ch,
             kappa_for_dc_ch,
             gmn_for_dc_ch,
-            out_dir,
+            extra_lines=RATE_PARAM_LINES,
+            out_dir=out_dir,
         )
 
 

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -291,18 +291,22 @@ def add_stats_kappas(yld_mc, kappas, skip_procs=[]):
 ########### Put stuff into form to pass to the function to write out cards ###########
 
 # Get just the numbers we want for rate row for datacard
-# Also sum all MC rates together into asimov number
+# Also sum all MC rates together into asimov number if not unblind
 # Assumes in_dict has nested keys: cat,syst,proc
-def get_rate_for_dc(in_dict,cat):
+def get_rate_for_dc(in_dict_mc,in_dict_data,cat,unblind):
     out_dict = {}
     asimov_data = 0
-    for proc in in_dict[cat]["nominal"]:
-        rate = in_dict[cat]["nominal"][proc][0]
+    for proc in in_dict_mc[cat]["nominal"]:
+        rate = in_dict_mc[cat]["nominal"][proc][0]
         if rate < 0:
             print(f"\nWarning: Process \"{proc}\" in \"{cat}\" has negative total rate: {rate}.\n")
         out_dict[proc] = str(rate)
         asimov_data += rate
-    out_dict["data_obs"] = str(asimov_data)
+
+    if not unblind:
+        out_dict["data_obs"] = str(asimov_data)
+    else:
+        out_dict["data_obs"] = str(in_dict_data[cat]["nominal"]["data"][0])
 
     return out_dict
 
@@ -448,7 +452,7 @@ def main():
     for ch in cat_lst:
 
         # Get just the info we want to put in the card in str form
-        rate_for_dc_ch = get_rate_for_dc(yld_dict_mc,ch)
+        rate_for_dc_ch = get_rate_for_dc(yld_dict_mc,yld_dict_data,ch,unblind)
 
         # Get the kappa and gamma dict for this channel if we are doing systs
         kappa_for_dc_ch = None

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -166,7 +166,7 @@ def handle_negatives(in_dict):
         for proc in in_dict[cat]["nominal"]:
             val = in_dict[cat]["nominal"][proc][0]
             var = in_dict[cat]["nominal"][proc][1]
-            if val < 0:
+            if val <= 0:
                 print(f"WARNING: Process \"{proc}\" in cat \"{cat}\" is negative ({val}), replacing with {SMALL} and shifting up/down systematic variations accordingly.")
                 out_dict[cat]["nominal"][proc][0] = SMALL
                 out_dict[cat]["nominal"][proc][1] = (abs(val) + np.sqrt(var))**2
@@ -300,6 +300,7 @@ def get_rate_for_dc(in_dict_mc,in_dict_data,cat,unblind):
         rate = in_dict_mc[cat]["nominal"][proc][0]
         if rate < 0:
             print(f"\nWarning: Process \"{proc}\" in \"{cat}\" has negative total rate: {rate}.\n")
+            raise Exception("This should not be happening. Exiting.")
         out_dict[proc] = str(rate)
         asimov_data += rate
 
@@ -401,6 +402,10 @@ def main():
     # We're only looking at Full R2 (run2) or 2022 (run3) for now
     yld_dict_mc = yld_dict_mc_allyears["FR"]
     yld_dict_data = yt.get_yields(histo,sample_names_dict_data["FR"])
+
+    # Scale yield for any processes (e.g. for testing impacts of small backgrounds)
+    scale_dict = {"WZ":1.0}
+    yld_dict_mc = yt.scale_yld_dict(yld_dict_mc,scale_dict)
 
     ####################################################################################
     # Dump some info about a bin (just raw numbers, more or less)

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -122,7 +122,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             "njets"   : axis.Regular(8, 0, 8, name="njets",   label="Jet multiplicity"),
             "nleps"   : axis.Regular(5, 0, 5, name="nleps",   label="Lep multiplicity"),
-            "nbtagsl" : axis.Regular(6, 0, 6, name="nbtagsl", label="Loose btag multiplicity"),
+            "nbtagsl" : axis.Regular(4, 0, 4, name="nbtagsl", label="Loose btag multiplicity"),
             "nbtagsm" : axis.Regular(4, 0, 4, name="nbtagsm", label="Medium btag multiplicity"),
 
             "njets_counts"   : axis.Regular(30, 0, 30, name="njets_counts",   label="Jet multiplicity counts"),
@@ -895,6 +895,14 @@ class AnalysisProcessor(processor.ProcessorABC):
             lepflav_4m = ((abs(l0.pdgId)==13) & (abs(l1.pdgId)==13) & (abs(l2.pdgId)==13) & (abs(l3.pdgId)==13))
             selections.add("cr_4l_btag_of",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of))
             selections.add("cr_4l_btag_sf_offZ_met80", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0)))
+
+            selections.add("cr_4l_btag_of_1b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl==1)))
+            selections.add("cr_4l_btag_of_2b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl==2)))
+            selections.add("cr_4l_btag_of_3b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl>=3)))
+            selections.add("cr_4l_btag_sf_offZ_met80_1b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl==1)))
+            selections.add("cr_4l_btag_sf_offZ_met80_2b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl==2)))
+            selections.add("cr_4l_btag_sf_offZ_met80_3b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl>=3)))
+
             selections.add("cr_4l_sf", (pass_trg & events.is4lWWZ & bmask_exactly0loose & events.wwz_presel_sf & (~w_candidates_mll_far_from_z)))
             # H->ZZ validation region: note, this is not enforced to be orthogonal to the SR, but it has effectively zero signal in it
             selections.add("cr_4l_sf_higgs", (pass_trg & events.is4lWWZ & events.wwz_presel_sf & ((mllll > 119) & (mllll < 131))))
@@ -1008,6 +1016,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     "sr_4l_sf_A","sr_4l_sf_B","sr_4l_sf_C","sr_4l_of_1","sr_4l_of_2","sr_4l_of_3","sr_4l_of_4",
                     "all_events","4l_presel", "sr_4l_sf", "sr_4l_of", "sr_4l_sf_incl", "sr_4l_of_incl",
                     "cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf", "cr_4l_sf_higgs",
+                    "cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_of_3b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b", "cr_4l_btag_sf_offZ_met80_3b",
                 ]
             }
 

--- a/ewkcoffea/modules/yield_tools.py
+++ b/ewkcoffea/modules/yield_tools.py
@@ -60,6 +60,20 @@ def get_yields(histo,sample_dict,blind=True,systematic_name=None):
 
 ############## Manipulating yields in a yield dict ##############
 
+# Scale processes in yield dictionary by a given factor
+# Will scale all systematic variations (not just nominal) by the factor
+# Returns a new dictionary, does not modify original
+def scale_yld_dict(in_yld_dict,scaling_dict):
+    out_dict = copy.deepcopy(in_yld_dict)
+    for cat in in_yld_dict:
+        for syst in in_yld_dict[cat]:
+            for proc in in_yld_dict[cat][syst]:
+                if proc in scaling_dict:
+                    out_dict[cat][syst][proc][0] = in_yld_dict[cat][syst][proc][0]*scaling_dict[proc]
+                    out_dict[cat][syst][proc][1] = in_yld_dict[cat][syst][proc][1]*scaling_dict[proc]
+    return out_dict
+
+
 # Calculate data-driven background estimation from relevant CRs
 def do_tf(yld_mc,yld_data,kappas,tf_map,quiet=True):
 

--- a/ewkcoffea/params/rate_systs.json
+++ b/ewkcoffea/params/rate_systs.json
@@ -3,10 +3,6 @@
         "lumi": 1.016
     },
     "rate_uncertainties_some_proc" : {
-        "qcd_scale": {
-            "procs": ["ttZ"],
-            "val": "0.898/1.117"
-        },
         "fake_fake": {
             "procs": ["WZ"],
             "val": "1.3"


### PR DESCRIPTION
In this PR:
* Add a function to scale a process in the yield dict (so that e.g. can test making a card with WZ scaled by 2x)
* In datacard maker, replace 0s (not just negative numbers)  with the `SMALL` value too 
* Add an unblind capability to the datacard maker (useful for the CR bins), but note the yield dictionary still sticks -99 something in for data in the SR, so that will have to be disabled too before we really unblind the SRs. 
* Drop the standin ttZ xsec uncertainty (it's not relevant since normalization is fit by rateParam)
* Add btag categories for ttZ CR to the processor (to use in SR+CR fit)
* Update datacard maker to make cards for SR+CR fit with rateParam functionality 

Also, unrelated to the other stuff in this PR, put a temporary pin in mt2 version (till the error introduced in 1.2.0 -> 1.2.1 is understood and fixed). 

With the SR+CR fitting (and all other minor changes from this branch), the new R2 ref is `4.72598`. 