### PR TITLE
Updates to datacard maker

### DIFF
--- a/analysis/wwz/get_wwz_yields.py
+++ b/analysis/wwz/get_wwz_yields.py
@@ -30,6 +30,7 @@ import yld_dicts_for_comp as yd
 #Other = (205, 205, 205) #CDCDCD
 CLR_LST = ["red","blue","#F09B9B","#00D091","#CDF09B","#A39B2F","#CDCDCD"] # If need extra color, "skyblue" is nice
 #CLR_LST = ["#F09B9B","#00D091","#CDF09B"]
+#CLR_LST = ["#A39B2F"] # Only WWZ
 
 
 BDT_INPUT_LST = [
@@ -729,7 +730,7 @@ def make_plots(histo_dict,grouping_mc,grouping_data,save_dir_path,apply_nsf_to_c
             # Rebin and set some x axis ranges (for the continous variables)
             # Skip this for discrete variables
             rangex = None
-            if var_name not in ["njets","nbtagsl","nleps","bdt_of_bin","bdt_sf_bin","bdt_of_bin_coarse","bdt_sf_bin_coarse","abs_pdgid_sum"]:
+            if var_name not in ["njets","nbtagsl","nleps","bdt_of_bin","bdt_sf_bin","bdt_of_bin_coarse","bdt_sf_bin_coarse","abs_pdgid_sum","w_lep0_genPartFlav","w_lep1_genPartFlav","z_lep0_genPartFlav","z_lep1_genPartFlav"]:
                 # Zoom in on mll around Z for Z CR
                 if (cat_name == "cr_4l_sf") and (var_name in ["mll_zl0_zl1","mll_wl0_wl1"]):
                     histo = rebin(histo,1)
@@ -900,9 +901,11 @@ def main():
 
         # Dump latex table for summary of CB, BDT, CRs
         hlines = [2,5] # Just summary categories
-        sr_cats_to_print = ["sr_of_all_cutbased","sr_sf_all_cutbased","sr_all_cutbased"] + ["sr_of_all_bdt","sr_sf_all_bdt","sr_all_bdt"] + ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]
         #hlines = [2,3,7,8,9,17,18,26,27,28] # All CB and BDT categories
+        #hlines = [2,3,7,8,9,13,14,18,19,20] # All CB and BDT categories for coarse binning
+        sr_cats_to_print = ["sr_of_all_cutbased","sr_sf_all_cutbased","sr_all_cutbased"] + ["sr_of_all_bdt","sr_sf_all_bdt","sr_all_bdt"] + ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]
         #sr_cats_to_print = sg.SR_SF_CB + ["sr_sf_all_cutbased"] + sg.SR_OF_CB + ["sr_of_all_cutbased","sr_all_cutbased"] + sg.SR_SF_BDT + ["sr_sf_all_bdt"] + sg.SR_OF_BDT + ["sr_of_all_bdt","sr_all_bdt"] + ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]
+        #sr_cats_to_print = sg.SR_SF_CB + ["sr_sf_all_cutbased"] + sg.SR_OF_CB + ["sr_of_all_cutbased","sr_all_cutbased"] + sg.SR_SF_BDT_COARSE + ["sr_sf_all_bdtCoarse"] + sg.SR_OF_BDT_COARSE + ["sr_of_all_bdtCoarse","sr_all_bdtCoarse"] + ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]
         procs_to_print = ["WWZ","ZH","Sig","ZZ","ttZ","tWZ","WZ","other","Bkg"]
         print_yields(yld_dict,sr_cats_to_print,procs_to_print,hlines=hlines,ref_dict=ref_ylds)
         #exit()

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -34,6 +34,13 @@ SYSTS_SPECIAL = {
         "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17"]},
     },
 
+    "run3" : {
+        "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["2022","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2023"       : {"yr_rel":"2023", "yr_notrel": ["2022","2022EE","2023BPix"]},
+        "btagSFbc_uncorrelated_2023BPix"   : {"yr_rel":"2023BPix", "yr_notrel": ["2022","2022EE","2023"]},
+    },
+
     "y22" : {
         "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["2022EE"]},
         "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["2022"]},

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -312,7 +312,14 @@ def get_kappa_dict(in_dict_mc,in_dict_data,yrs_lst):
 
                 # Handle negative cases
                 if (valvar_kappa_up[0]<=0) and (valvar_kappa_do[0]<=0):
-                    raise Exception(f"Both Kappas Neagtive for process: {proc}, category: {cat}, systematic: {sys}")
+                    if (set(yrs_lst) == set(["2022","2022EE","2023","2023BPix"])) and (cat=="sr_4l_bdt_of_1") and (sys=="FSR") and (proc=="ttZ"):
+                        # One known case of this: FSR for ttZ for sr_4l_bdt_of_1 for r3
+                        #   - Does not matter since we don't use this bin, so skip it
+                        #   - Super super hard coded skip for this case:
+                        print("Kappas in same direction, but for a bin that's not used. So we don't care right now.")
+                    else:
+                        # Otherwise raise an error, we should stop and take a look at what's happening
+                        raise Exception(f"Both Kappas Neagtive for process: {proc}, category: {cat}, systematic: {sys}")
                 if valvar_kappa_up[0] <= 0:
                     print(f"WARNING: Up var for {sys} for {proc} for {cat} is negative, setting to {SMALL}.")
                     valvar_kappa_up[0] = SMALL
@@ -510,7 +517,10 @@ def main():
     kappa_dict = None
     if do_nuis:
         kappa_dict = get_kappa_dict(yld_dict_mc,yld_dict_data,yrs_lst)
-        kappa_dict = add_stats_kappas(yld_dict_mc,kappa_dict,skip_procs=["ZZ","ttZ"])
+        # Don't do mc stats kappas for data-driven bkg if doing TFs
+        if do_tf: skip_stats_kappas_lst = ["ZZ","ttZ"]
+        else: skip_stats_kappas_lst = []
+        kappa_dict = add_stats_kappas(yld_dict_mc,kappa_dict,skip_procs=skip_stats_kappas_lst)
 
     # Do the TF calculation
     if do_tf:

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -81,7 +81,7 @@ RATE_PARAM_LINES = [
 ########### Writing the datacard ###########
 
 # Make the datacard for a given channel
-def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,extra_lines=None,out_dir="."):
+def make_ch_card(ch,proc_order,year_name,ch_ylds,ch_kappas=None,ch_gmn=None,extra_lines=None,out_dir="."):
 
     # Building blocks we'll need to build the card formatting
     bin_str = f"bin_{ch}"
@@ -92,7 +92,7 @@ def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,extra_lines=No
     left_width = max(syst_width+len("shape")+1,left_width)
 
     # The output name, location
-    outf_card_name = f"wwz4l_card_{ch}.txt"
+    outf_card_name = f"wwz4l_card_{ch}_{year_name}.txt"
     print(f"Generating text file: {out_dir}/{outf_card_name}")
     outf_card_name = os.path.join(out_dir,outf_card_name)
 
@@ -569,6 +569,7 @@ def main():
         make_ch_card(
             ch,
             sg.PROC_LST,
+            run,
             rate_for_dc_ch,
             kappa_for_dc_ch,
             gmn_for_dc_ch,

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -248,16 +248,26 @@ def get_rate_systs(proc_lst,year_tag):
 
     # Make rows for rate uncertainties that impact a subset of the processes
     for uncty_name in rate_systs_dict["rate_uncertainties_some_proc"]:
+
+        # If the uncty has a decorrelation_dict defined, use that to append a tag to the name of the uncty
+        # E.g., for the fake uncertianty, we append the run so that it is fake_run2 or fake_run3
+        if "decorrelation_dict" in rate_systs_dict["rate_uncertainties_some_proc"][uncty_name]:
+            tag = "_" + rate_systs_dict["rate_uncertainties_some_proc"][uncty_name]["decorrelation_dict"][year_tag]
+        else:
+            uncty_name_tag = ""
+
+        # Loop over procs and put in the uncty or "-" if NA
         for proc_of_interest in rate_systs_dict["rate_uncertainties_some_proc"][uncty_name]["procs"]:
-            out_dict[f"{uncty_name}_{proc_of_interest}"] = {}
+            out_dict[f"{uncty_name}_{proc_of_interest}{tag}"] = {}
             for proc_itr in proc_lst:
                 if proc_itr == proc_of_interest:
                     uncty = str(rate_systs_dict["rate_uncertainties_some_proc"][uncty_name]["val"])
                 else:
                     uncty = "-"
-                out_dict[f"{uncty_name}_{proc_of_interest}"][proc_itr] = uncty
+                out_dict[f"{uncty_name}_{proc_of_interest}{tag}"][proc_itr] = uncty
 
     return out_dict
+
 
 #Determines if the up and down variations of a systematic are in the same direction
 def determine_updo_same(nom,up,down):

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -16,35 +16,52 @@ SMALL = 0.000001
 # Global variables
 PRECISION = 6   # Decimal point precision in the text datacard output
 
+# What each recognized year grouping consists of
+ALL_YEARS_LST = ["UL16","UL16APV","UL17","UL18", "2022","2022EE", "2023","2023BPix"]
+
 # Systs that are not correlated across years
-SYSTS_SPECIAL_RUN2 = {
-    "btagSFlight_uncorrelated_2016APV" : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18"]},
-    "btagSFbc_uncorrelated_2016APV"    : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18"]},
-    "btagSFlight_uncorrelated_2016"    : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18"]},
-    "btagSFbc_uncorrelated_2016"       : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18"]},
-    "btagSFlight_uncorrelated_2017"    : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18"]},
-    "btagSFbc_uncorrelated_2017"       : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18"]},
-    "btagSFlight_uncorrelated_2018"    : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17"]},
-    "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17"]},
-}
-SYSTS_SPECIAL_RUN3 = {
-    "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["2022EE"]},
-    "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["2022"]},
+
+SYSTS_SPECIAL = {
+
+    "run2" : {
+        "btagSFlight_uncorrelated_2016APV" : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18"]},
+        "btagSFbc_uncorrelated_2016APV"    : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18"]},
+        "btagSFlight_uncorrelated_2016"    : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18"]},
+        "btagSFbc_uncorrelated_2016"       : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18"]},
+        "btagSFlight_uncorrelated_2017"    : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18"]},
+        "btagSFbc_uncorrelated_2017"       : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18"]},
+        "btagSFlight_uncorrelated_2018"    : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17"]},
+        "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17"]},
+    },
+
+    "y22" : {
+        "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["2022EE"]},
+        "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["2022"]},
+    },
+
+    "y23" : {
+        "btagSFbc_uncorrelated_2023"       : {"yr_rel":"2023", "yr_notrel": ["2023BPix"]},
+        "btagSFbc_uncorrelated_2023BPix"   : {"yr_rel":"2023BPix", "yr_notrel": ["2023"]},
+    },
+
+    "all" : {
+        "btagSFlight_uncorrelated_2016APV" : {"yr_rel":"UL16APV", "yr_notrel": ["UL16","UL17","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2016APV"    : {"yr_rel":"UL16APV", "yr_notrel": ["UL16","UL17","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFlight_uncorrelated_2016"    : {"yr_rel":"UL16", "yr_notrel": ["UL16APV","UL17","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2016"       : {"yr_rel":"UL16", "yr_notrel": ["UL16APV","UL17","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFlight_uncorrelated_2017"    : {"yr_rel":"UL17", "yr_notrel": ["UL16APV","UL16","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2017"       : {"yr_rel":"UL17", "yr_notrel": ["UL16APV","UL16","UL18","2022","2022EE","2023","2023BPix"]},
+        "btagSFlight_uncorrelated_2018"    : {"yr_rel":"UL18", "yr_notrel": ["UL16APV","UL16","UL17","2022","2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV","UL16","UL17","2022","2022EE","2023","2023BPix"]},
+
+        "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022EE","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2023","2023BPix"]},
+        "btagSFbc_uncorrelated_2023"       : {"yr_rel":"2023", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2022EE","2023BPix"]},
+        "btagSFbc_uncorrelated_2023BPix"   : {"yr_rel":"2023BPix", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2022EE","2023"]},
+    }
+
 }
 
-SYSTS_SPECIAL_ALL = {
-    "btagSFlight_uncorrelated_2016APV" : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18", "2022", "2022EE"]},
-    "btagSFbc_uncorrelated_2016APV"    : {"yr_rel":"UL16APV", "yr_notrel": ["UL16", "UL17", "UL18", "2022", "2022EE"]},
-    "btagSFlight_uncorrelated_2016"    : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18", "2022", "2022EE"]},
-    "btagSFbc_uncorrelated_2016"       : {"yr_rel":"UL16", "yr_notrel": ["UL16APV", "UL17", "UL18", "2022", "2022EE"]},
-    "btagSFlight_uncorrelated_2017"    : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18", "2022", "2022EE"]},
-    "btagSFbc_uncorrelated_2017"       : {"yr_rel":"UL17", "yr_notrel": ["UL16APV", "UL16", "UL18", "2022", "2022EE"]},
-    "btagSFlight_uncorrelated_2018"    : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17", "2022", "2022EE"]},
-    "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV", "UL16", "UL17", "2022", "2022EE"]},
-
-    "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022EE"]},
-    "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022"]},
-}
 
 # Hard code the rateParam lines to put at the end of the card (for background normalization)
 RATE_PARAM_LINES = [
@@ -159,13 +176,8 @@ def make_ch_card(ch,proc_order,ch_ylds,ch_kappas=None,ch_gmn=None,extra_lines=No
 #   - Because of how we fill in the processor, the yields for per year systs come _only_ from that year
 #   - So this function adds the nominal yields from the other three years to the up/down variation for the relevant year
 #   - Note the in_dict is modifed in place (we do not return a copy of the dict)
-def handle_per_year_systs_for_fr(in_dict,year):
-    if year == "all":
-        systs_special=SYSTS_SPECIAL_ALL
-    if year in ["2022","2022EE","run3","y22","y23"]:
-        systs_special=SYSTS_SPECIAL_RUN3
-    if year in ["UL16","UL16APV","UL17","UL18","run2"]:
-        systs_special=SYSTS_SPECIAL_RUN2
+def handle_per_year_systs_for_fr(in_dict,year_name):
+    systs_special = SYSTS_SPECIAL[year_name]
     for cat in in_dict["FR"].keys():
         for sys in systs_special:
             # Find up/down variation for the year relevant to that syst
@@ -256,7 +268,7 @@ def fix_updown_same(nom,up,down):
     return kappa_up, kappa_down
 
 # Get kappa dict (e.g. up/nom ratios) from the dict of all histograms
-def get_kappa_dict(in_dict_mc,in_dict_data):
+def get_kappa_dict(in_dict_mc,in_dict_data,yrs_lst):
 
     # Get the list of systematic base names (i.e. without the up and down tags)
     #     - Assumes each syst has a "systnameUp" and a "systnameDown"
@@ -275,8 +287,15 @@ def get_kappa_dict(in_dict_mc,in_dict_data):
     for cat in in_dict_mc.keys():
         kappa_dict[cat] = {}
         for sys in get_syst_base_name_lst(list(in_dict_mc[cat].keys())):
+
+            # Skip year specific systs that are not relevant
+            # E.g. if the pkl file is all r3, but we're only making a 22 datacard, skip btagSFbc_uncorrelated_2023BPix variation
+            # Do this by checking if the syst name ends with a year, and then if that year is in our list for this card
+            if (sys.split("_")[-1] in ALL_YEARS_LST) and (sys.split("_")[-1] not in yrs_lst): continue
+
             kappa_dict[cat][sys] = {}
             for proc in in_dict_mc[cat]["nominal"]:
+
                 kappa_dict[cat][sys][proc] = {}
                 valvar_up = in_dict_mc[cat][f"{sys}Up"][proc]
                 valvar_do = in_dict_mc[cat][f"{sys}Down"][proc]
@@ -422,6 +441,14 @@ def main():
         print(f"Making dir \"{out_dir}\"")
         os.makedirs(out_dir)
 
+    # Set list of years from the run name
+    if   run == "all" : yrs_lst = ["UL16APV","UL16","UL17","UL18", "2022","2022EE","2023","2023BPix"]
+    elif run == "run2": yrs_lst = ["UL16APV","UL16","UL17","UL18"]
+    elif run == "run3": yrs_lst = ["2022","2022EE","2023","2023BPix"]
+    elif run == "y22" : yrs_lst = ["2022","2022EE"]
+    elif run == "y23" : yrs_lst = ["2023","2023BPix"]
+    else: raise Exception("Unknown year")
+
     # Get the histo
     f = pickle.load(gzip.open(in_file))
     histo = f["njets"] # Let's use njets
@@ -429,31 +456,8 @@ def main():
     # Get the dictionary defining the mc sample grouping
     sample_names_dict_data = {"FR" : sg.create_data_sample_dict(run)}
     sample_names_dict_mc   = {"FR" : sg.create_mc_sample_dict(run)}
-    if run == "all":
-        sample_names_dict_mc["UL16APV"] = sg.create_mc_sample_dict("UL16APV")
-        sample_names_dict_mc["UL16"]    = sg.create_mc_sample_dict("UL16")
-        sample_names_dict_mc["UL17"]    = sg.create_mc_sample_dict("UL17")
-        sample_names_dict_mc["UL18"]    = sg.create_mc_sample_dict("UL18")
-        sample_names_dict_mc["2022"]    = sg.create_mc_sample_dict("2022")
-        sample_names_dict_mc["2022EE"]  = sg.create_mc_sample_dict("2022EE")
-        #sample_names_dict_mc["2023"]  = sg.create_mc_sample_dict("2023")
-        #sample_names_dict_mc["2023BPix"]  = sg.create_mc_sample_dict("2023BPix")
-    if run == "run2":
-        sample_names_dict_mc["UL16APV"] = sg.create_mc_sample_dict("UL16APV")
-        sample_names_dict_mc["UL16"]    = sg.create_mc_sample_dict("UL16")
-        sample_names_dict_mc["UL17"]    = sg.create_mc_sample_dict("UL17")
-        sample_names_dict_mc["UL18"]    = sg.create_mc_sample_dict("UL18")
-    if run == "run3":
-        sample_names_dict_mc["2022"]    = sg.create_mc_sample_dict("2022")
-        sample_names_dict_mc["2022EE"]  = sg.create_mc_sample_dict("2022EE")
-        #sample_names_dict_mc["2023"]  = sg.create_mc_sample_dict("2023")
-        #sample_names_dict_mc["2023BPix"]  = sg.create_mc_sample_dict("2023BPix")
-    if run == "y22":
-        sample_names_dict_mc["2022"]    = sg.create_mc_sample_dict("2022")
-        sample_names_dict_mc["2022EE"]  = sg.create_mc_sample_dict("2022EE")
-    if run == "y23":
-        sample_names_dict_mc["2023"]  = sg.create_mc_sample_dict("2023")
-        sample_names_dict_mc["2023BPix"]  = sg.create_mc_sample_dict("2023BPix")
+    for year_indiv_name in yrs_lst:
+        sample_names_dict_mc[year_indiv_name] = sg.create_mc_sample_dict(year_indiv_name)
 
     # Get yield dictionary (nested in the order: year,cat,syst,proc)
     yld_dict_mc_allyears = {}
@@ -498,7 +502,7 @@ def main():
     # Get the syst ratios to nominal (i.e. kappas)
     kappa_dict = None
     if do_nuis:
-        kappa_dict = get_kappa_dict(yld_dict_mc,yld_dict_data)
+        kappa_dict = get_kappa_dict(yld_dict_mc,yld_dict_data,yrs_lst)
         kappa_dict = add_stats_kappas(yld_dict_mc,kappa_dict,skip_procs=["ZZ","ttZ"])
 
     # Do the TF calculation

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -51,22 +51,6 @@ SYSTS_SPECIAL = {
         "btagSFbc_uncorrelated_2023BPix"   : {"yr_rel":"2023BPix", "yr_notrel": ["2023"]},
     },
 
-    "all" : {
-        "btagSFlight_uncorrelated_2016APV" : {"yr_rel":"UL16APV", "yr_notrel": ["UL16","UL17","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2016APV"    : {"yr_rel":"UL16APV", "yr_notrel": ["UL16","UL17","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFlight_uncorrelated_2016"    : {"yr_rel":"UL16", "yr_notrel": ["UL16APV","UL17","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2016"       : {"yr_rel":"UL16", "yr_notrel": ["UL16APV","UL17","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFlight_uncorrelated_2017"    : {"yr_rel":"UL17", "yr_notrel": ["UL16APV","UL16","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2017"       : {"yr_rel":"UL17", "yr_notrel": ["UL16APV","UL16","UL18","2022","2022EE","2023","2023BPix"]},
-        "btagSFlight_uncorrelated_2018"    : {"yr_rel":"UL18", "yr_notrel": ["UL16APV","UL16","UL17","2022","2022EE","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2018"       : {"yr_rel":"UL18", "yr_notrel": ["UL16APV","UL16","UL17","2022","2022EE","2023","2023BPix"]},
-
-        "btagSFbc_uncorrelated_2022"       : {"yr_rel":"2022", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022EE","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2022EE"     : {"yr_rel":"2022EE", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2023","2023BPix"]},
-        "btagSFbc_uncorrelated_2023"       : {"yr_rel":"2023", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2022EE","2023BPix"]},
-        "btagSFbc_uncorrelated_2023BPix"   : {"yr_rel":"2023BPix", "yr_notrel": ["UL16APV","UL16","UL17","UL18","2022","2022EE","2023"]},
-    }
-
 }
 
 
@@ -546,9 +530,7 @@ def main():
     cat_lst_cr = ["cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_of_3b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b", "cr_4l_btag_sf_offZ_met80_3b","cr_4l_sf"]
     cat_lst_sr = sg.CAT_LST_CB
     if use_bdt_sr:
-        if run == "all":
-            cat_lst_sr = sg.CAT_LST_BDT
-        elif run in ["run2"]:
+        if run in ["run2"]:
             cat_lst_sr = sg.CAT_LST_BDT
         elif run in ["run3", "y22", "y23"]:
             cat_lst_sr = sg.CAT_LST_BDT_COARSE

--- a/analysis/wwz/make_datacards_wrapper.sh
+++ b/analysis/wwz/make_datacards_wrapper.sh
@@ -1,0 +1,9 @@
+# Wrapper around making full analysis test data cards
+
+R2_PKL="wwz_histos.pkl.gz"
+R3_PKL="r3_wwz_histos_withSyst.pkl.gz"
+
+rm cards_wwz4l/*
+
+python make_datacards.py histos/$R3_PKL -u run3 -s --bdt
+python make_datacards.py histos/$R2_PKL -u run2 -s --bdt

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -233,6 +233,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         is2022 = year in ["2022","2022EE"]
         is2023 = year in ["2023","2023BPix"]
 
+        if is2022 or is2023:
+            run_tag = "run3"
+        elif year in ["2016","2016APV","2017","2018"]:
+            run_tag = "run2"
+        else:
+            raise Exception(f"ERROR: Unknown year {year}.")
+
         # If this is a 2022 sample, get the era info
         if isData and (is2022 or is2023):
             era = self._samples[json_name]["era"]
@@ -407,14 +414,14 @@ class AnalysisProcessor(processor.ProcessorABC):
                 weights_obj_base.add("PU", cor_ec.run3_pu_attach(events.Pileup,year,"nominal"), cor_ec.run3_pu_attach(events.Pileup,year,"hi"), cor_ec.run3_pu_attach(events.Pileup,year,"lo"))
 
             # Lepton SFs and systs
-            weights_obj_base.add("lepSF_muon", events.sf_4l_muon, copy.deepcopy(events.sf_4l_hi_muon), copy.deepcopy(events.sf_4l_lo_muon))
-            weights_obj_base.add("lepSF_elec", events.sf_4l_elec, copy.deepcopy(events.sf_4l_hi_elec), copy.deepcopy(events.sf_4l_lo_elec))
+            weights_obj_base.add(f"lepSF_muon_{run_tag}", events.sf_4l_muon, copy.deepcopy(events.sf_4l_hi_muon), copy.deepcopy(events.sf_4l_lo_muon))
+            weights_obj_base.add(f"lepSF_elec_{run_tag}", events.sf_4l_elec, copy.deepcopy(events.sf_4l_hi_elec), copy.deepcopy(events.sf_4l_lo_elec))
 
 
         # Set up the list of systematics that are handled via event weight variations
         wgt_correction_syst_lst_common = [
             "btagSFbc_correlated", f"btagSFbc_uncorrelated_{year}",
-            "lepSF_elec", "lepSF_muon", "PU",
+            f"lepSF_elec_{run_tag}", f"lepSF_muon_{run_tag}", "PU",
             "renorm", "fact", "ISR", "FSR",
         ]
         if not (is2022 or is2023):

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -86,6 +86,11 @@ class AnalysisProcessor(processor.ProcessorABC):
             "mll_wl0_wl1" : axis.Regular(180, 0, 350, name="mll_wl0_wl1", label="mll(W lep0, W lep1)"),
             "mll_zl0_zl1" : axis.Regular(180, 0, 200, name="mll_zl0_zl1", label="mll(Z lep0, Z lep1)"),
 
+            "w_lep0_genPartFlav"  : axis.Regular(20, 0, 20, name="w_lep0_genPartFlav", label="Leading W lep genPartFlav"),
+            "w_lep1_genPartFlav"  : axis.Regular(20, 0, 20, name="w_lep1_genPartFlav", label="Subleading W lep genPartFlav"),
+            "z_lep0_genPartFlav"  : axis.Regular(20, 0, 20, name="z_lep0_genPartFlav", label="Leading Z lep genPartFlav"),
+            "z_lep1_genPartFlav"  : axis.Regular(20, 0, 20, name="z_lep1_genPartFlav", label="Subleading Z lep genPartFlav"),
+
             "pt_zl0_zl1" : axis.Regular(180, 0, 300, name="pt_zl0_zl1", label="pt(Zl0 + Zl1)"),
             "pt_wl0_wl1" : axis.Regular(180, 0, 300, name="pt_wl0_wl1", label="pt(Wl0 + Wl1)"),
             "dr_zl0_zl1" : axis.Regular(180, 0, 5, name="dr_zl0_zl1", label="dr(Zl0,Zl1)"),
@@ -747,6 +752,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "mlb_max" : mlb_max,
 
             }
+            # Include the genPartFlav, though this is only defined for MC, so just fill with 1 if data
+            dense_variables_dict["w_lep0_genPartFlav"] = w_lep0.genPartFlav if not isData else events.nom
+            dense_variables_dict["w_lep1_genPartFlav"] = w_lep1.genPartFlav if not isData else events.nom
+            dense_variables_dict["z_lep0_genPartFlav"] = z_lep0.genPartFlav if not isData else events.nom
+            dense_variables_dict["z_lep1_genPartFlav"] = z_lep1.genPartFlav if not isData else events.nom
 
 
             ######### Evaluate the BDTs (get WWZ, ZH, and WZ scores for SF and OF) #########
@@ -1054,6 +1064,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "mll_zl0_zl1" : ["all_events"],
 
                 "abs_pdgid_sum" : ["all_events"],
+
+                "w_lep0_genPartFlav" : ["all_events"],
+                "w_lep1_genPartFlav" : ["all_events"],
+                "z_lep0_genPartFlav" : ["all_events"],
+                "z_lep1_genPartFlav" : ["all_events"],
 
                 "pt_zl0_zl1" : ["all_events"],
                 "pt_wl0_wl1" : ["all_events"],

--- a/ewkcoffea/params/rate_systs.json
+++ b/ewkcoffea/params/rate_systs.json
@@ -1,9 +1,14 @@
 {
     "rate_uncertainties_all_proc" : {
-        "lumi": 1.016
+        "lumi": {
+            "run2" : 1.016,
+            "run3" : 1.014,
+            "y22"  : 1.014,
+            "y23"  : 1.014
+        }
     },
     "rate_uncertainties_some_proc" : {
-        "fake_fake": {
+        "fake": {
             "procs": ["WZ"],
             "val": "1.3"
         }

--- a/ewkcoffea/params/rate_systs.json
+++ b/ewkcoffea/params/rate_systs.json
@@ -9,8 +9,14 @@
     },
     "rate_uncertainties_some_proc" : {
         "fake": {
-            "procs": ["WZ"],
-            "val": "1.3"
+            "procs" : ["WZ"],
+            "val"   : "1.3",
+            "decorrelation_dict" : {
+                "run2" : "run2",
+                "run3" : "run3",
+                "y22"  : "run3",
+                "y23"  : "run3"
+            }
         }
     }
 }


### PR DESCRIPTION
In this PR:
* Fix issue of skipping ttZ/ZZ MC stats (since had been left out when we were doing TF stuff) 
* De correlate relevant systematics (lep SFs, fake)
* Use correct lumi uncertainty for R3 
* Removed "all" option from datacard maker, as it was not properly working before anyway (and the way we've decided to handle R2 and R3 is to just call the data card maker twice)
* Added script for running the "official" datacards `make_datacards_wrapper.sh`
* Unrelated updates: Added a few histograms for `genPartFlav` of the leptons (for unrelated studies that were happening at the same time). 

This brings the repo up to date with the results presented at SMP-VV on Sep 12, 2024. The relevant ref number is `5.43518`.