### PR TITLE
Rebin btag hists

### DIFF
--- a/analysis/wwz/full_run2_run.sh
+++ b/analysis/wwz/full_run2_run.sh
@@ -1,7 +1,7 @@
 # Some example commands for running at scale
 
 
-### Examples with 3l skim configs ###
+### Examples with 3l skim configs (OLD) ###
 
 # Run at scale with futures DO NOT RUN THIS ON LOGIN NODE!
 #time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/mc_sig_bkg_samples.cfg,../../input_samples/cfgs/wwz_analysis/data_samples.cfg -o wwz_histos -x futures -n 128
@@ -16,12 +16,12 @@
 ### Examples with 4l skims configs ### (ONLY WORKS AT UAF. SAMPLES HAVE NOT BEEN MOVED TO HPG!)
 
 # Run at scale with futures
-#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -s 100000000 -o wwz_histos --hist-list bdt
-#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -s 100000000 -o wwz_histos --hist-list njets njets_counts --do-systs
+#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -s 100000000 -o r2_wwz_histos_noSyst --hist-list bdt
+time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -s 100000000 -o r2_wwz_histos_withSyst --hist-list njets njets_counts --do-systs
 
 # Run with the siphon turned on (might want to comment out data in the input cfg)
-#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -o wwz_histos_siphon --siphon
+#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -x futures -n 200 -o r2_wwz_histos_noSyst_siphon --siphon
 
 # Run at scale with wq
-#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -o wwz_histos_noSys --hist-list bdt
-time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -o wwz_histos_withSys --hist-list njets njets_counts --do-systs
+#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -o r2_wwz_histos_noSyst --hist-list bdt
+#time python run_wwz4l.py ../../input_samples/cfgs/wwz_analysis/samples_4lskim_run2_v1.cfg -o r2_wwz_histos_withSyst --hist-list njets njets_counts --do-systs

--- a/analysis/wwz/get_wwz_yields.py
+++ b/analysis/wwz/get_wwz_yields.py
@@ -29,6 +29,7 @@ import yld_dicts_for_comp as yd
 #tWZ   = (205, 240, 155) #CDF09B
 #Other = (205, 205, 205) #CDCDCD
 CLR_LST = ["red","blue","#F09B9B","#00D091","#CDF09B","#A39B2F","#CDCDCD"] # If need extra color, "skyblue" is nice
+#CLR_LST = ["red","blue","#F09B9B","#00D091","#CDF09B","#A39B2F","#CDCDCD","skyblue"] # If need extra color, "skyblue" is nice
 #CLR_LST = ["#F09B9B","#00D091","#CDF09B"]
 #CLR_LST = ["#A39B2F"] # Only WWZ
 
@@ -258,7 +259,9 @@ def print_yields(yld_dict_in,cats_to_print,procs_to_print,do_comp=True,ref_dict=
         print_end_info=True,
         print_errs=True,
         column_variable="subkeys",
+        #column_variable="keys",
         size="tiny",
+        hz_line_lst=hlines,
     )
     if not do_comp: return
 
@@ -719,6 +722,7 @@ def make_plots(histo_dict,grouping_mc,grouping_data,save_dir_path,apply_nsf_to_c
             # Skip some of the cats if you want to
             #if "bdt" in cat_name: continue
             #if cat_name not in ["sr_4l_sf_incl", "sr_4l_of_incl", "cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf", "sr_4l_bdt_sf_trn", "sr_4l_bdt_of_trn"]: continue # TMP
+            #if cat_name not in ["sr_4l_sf_incl", "sr_4l_of_incl"]: continue
             #if cat_name not in ["cr_4l_sf_higgs"]: continue
             #if cat_name not in ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]: continue
             if cat_name not in ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf", "sr_4l_bdt_sf_trn", "sr_4l_bdt_of_trn"]: continue
@@ -899,6 +903,14 @@ def main():
         if args.ul_year in ["run2","UL18","UL17","UL16","UL16APV"]: ref_ylds = ref_dict=yd.EWK_REF
         if args.ul_year in ["run3","y22","y23","2022","2022EE","2023","2023BPix"]: ref_ylds = ref_dict=yd.EWK_REF_2022
 
+        # Dump latex table for cutflow
+        # Might want to swap order of rows and columns in print_yields
+        hlines = [0,1,3]
+        sr_cats_to_print = ["all_events", "4l_presel", "sr_4l_bdt_of_presel", "sr_4l_bdt_sf_presel", "sr_4l_bdt_of_trn", "sr_4l_bdt_sf_trn"]
+        procs_to_print = ["WWZ","ZH","ZZ","ttZ","tWZ","WZ","other"]
+        print_yields(yld_dict,sr_cats_to_print,procs_to_print,hlines=hlines,ref_dict=None,do_comp=False)
+        #exit()
+
         # Dump latex table for summary of CB, BDT, CRs
         hlines = [2,5] # Just summary categories
         #hlines = [2,3,7,8,9,17,18,26,27,28] # All CB and BDT categories
@@ -908,7 +920,7 @@ def main():
         #sr_cats_to_print = sg.SR_SF_CB + ["sr_sf_all_cutbased"] + sg.SR_OF_CB + ["sr_of_all_cutbased","sr_all_cutbased"] + sg.SR_SF_BDT_COARSE + ["sr_sf_all_bdtCoarse"] + sg.SR_OF_BDT_COARSE + ["sr_of_all_bdtCoarse","sr_all_bdtCoarse"] + ["cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf"]
         procs_to_print = ["WWZ","ZH","Sig","ZZ","ttZ","tWZ","WZ","other","Bkg"]
         print_yields(yld_dict,sr_cats_to_print,procs_to_print,hlines=hlines,ref_dict=ref_ylds)
-        #exit()
+        exit()
 
         # Dump latex table for cut based
         hlines = [2,3,7,8]

--- a/analysis/wwz/make_datacards.py
+++ b/analysis/wwz/make_datacards.py
@@ -526,7 +526,7 @@ def main():
     #### Make the cards for each channel ####
 
     # Get list of channels
-    cat_lst_cr = ["cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_of_3b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b", "cr_4l_btag_sf_offZ_met80_3b","cr_4l_sf"]
+    cat_lst_cr = ["cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b","cr_4l_sf"]
     cat_lst_sr = sg.CAT_LST_CB
     if use_bdt_sr:
         if run in ["run2"]:

--- a/analysis/wwz/make_datacards_wrapper.sh
+++ b/analysis/wwz/make_datacards_wrapper.sh
@@ -1,6 +1,6 @@
 # Wrapper around making full analysis test data cards
 
-R2_PKL="wwz_histos.pkl.gz"
+R2_PKL="r2_wwz_histos_withSyst.pkl.gz"
 R3_PKL="r3_wwz_histos_withSyst.pkl.gz"
 
 rm cards_wwz4l/*

--- a/analysis/wwz/ref_for_ci/counts_wwz_ref.json
+++ b/analysis/wwz/ref_for_ci/counts_wwz_ref.json
@@ -85,11 +85,7 @@
             null
         ],
         "cr_4l_btag_of_2b_counts": [
-            141.0,
-            null
-        ],
-        "cr_4l_btag_of_3b_counts": [
-            23.0,
+            164.0,
             null
         ],
         "cr_4l_btag_sf_offZ_met80_1b_counts": [
@@ -97,11 +93,7 @@
             null
         ],
         "cr_4l_btag_sf_offZ_met80_2b_counts": [
-            57.0,
-            null
-        ],
-        "cr_4l_btag_sf_offZ_met80_3b_counts": [
-            12.0,
+            69.0,
             null
         ],
         "sr_4l_bdt_sf_1_counts": [
@@ -305,11 +297,7 @@
             null
         ],
         "cr_4l_btag_of_2b": [
-            0.16339887317148746,
-            null
-        ],
-        "cr_4l_btag_of_3b": [
-            0.036928270979461865,
+            0.2003271441509493,
             null
         ],
         "cr_4l_btag_sf_offZ_met80_1b": [
@@ -317,11 +305,7 @@
             null
         ],
         "cr_4l_btag_sf_offZ_met80_2b": [
-            0.06263347611175435,
-            null
-        ],
-        "cr_4l_btag_sf_offZ_met80_3b": [
-            0.017881120829277012,
+            0.08051459694103139,
             null
         ],
         "sr_4l_bdt_sf_1": [

--- a/analysis/wwz/ref_for_ci/counts_wwz_ref_2022.json
+++ b/analysis/wwz/ref_for_ci/counts_wwz_ref_2022.json
@@ -76,6 +76,18 @@
             11.0,
             null
         ],
+        "cr_4l_btag_of_1b_counts": [
+            16.0,
+            null
+        ],
+        "cr_4l_btag_of_2b_counts": [
+            1.0,
+            null
+        ],
+        "cr_4l_btag_sf_offZ_met80_1b_counts": [
+            3.0,
+            null
+        ],
         "sr_4l_bdt_sf_1_counts": [
             8.0,
             null
@@ -266,6 +278,18 @@
         ],
         "cr_4l_sf": [
             0.0486325724430299,
+            null
+        ],
+        "cr_4l_btag_of_1b": [
+            0.10836821746812628,
+            null
+        ],
+        "cr_4l_btag_of_2b": [
+            0.005244452405730966,
+            null
+        ],
+        "cr_4l_btag_sf_offZ_met80_1b": [
+            0.026062029860875337,
             null
         ],
         "sr_4l_bdt_sf_1": [

--- a/analysis/wwz/wwz4l.py
+++ b/analysis/wwz/wwz4l.py
@@ -127,7 +127,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             "njets"   : axis.Regular(8, 0, 8, name="njets",   label="Jet multiplicity"),
             "nleps"   : axis.Regular(5, 0, 5, name="nleps",   label="Lep multiplicity"),
-            "nbtagsl" : axis.Regular(4, 0, 4, name="nbtagsl", label="Loose btag multiplicity"),
+            "nbtagsl" : axis.Regular(3, 0, 3, name="nbtagsl", label="Loose btag multiplicity"),
             "nbtagsm" : axis.Regular(4, 0, 4, name="nbtagsm", label="Medium btag multiplicity"),
 
             "njets_counts"   : axis.Regular(30, 0, 30, name="njets_counts",   label="Jet multiplicity counts"),
@@ -914,11 +914,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             selections.add("cr_4l_btag_sf_offZ_met80", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0)))
 
             selections.add("cr_4l_btag_of_1b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl==1)))
-            selections.add("cr_4l_btag_of_2b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl==2)))
-            selections.add("cr_4l_btag_of_3b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl>=3)))
+            selections.add("cr_4l_btag_of_2b",            (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_of & (nbtagsl>=2)))
             selections.add("cr_4l_btag_sf_offZ_met80_1b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl==1)))
-            selections.add("cr_4l_btag_sf_offZ_met80_2b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl==2)))
-            selections.add("cr_4l_btag_sf_offZ_met80_3b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl>=3)))
+            selections.add("cr_4l_btag_sf_offZ_met80_2b", (pass_trg & events.is4lWWZ & bmask_atleast1loose & events.wwz_presel_sf & w_candidates_mll_far_from_z & (met.pt > 80.0) & (nbtagsl>=2)))
 
             selections.add("cr_4l_sf", (pass_trg & events.is4lWWZ & bmask_exactly0loose & events.wwz_presel_sf & (~w_candidates_mll_far_from_z)))
             # H->ZZ validation region: note, this is not enforced to be orthogonal to the SR, but it has effectively zero signal in it
@@ -1033,7 +1031,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                     "sr_4l_sf_A","sr_4l_sf_B","sr_4l_sf_C","sr_4l_of_1","sr_4l_of_2","sr_4l_of_3","sr_4l_of_4",
                     "all_events","4l_presel", "sr_4l_sf", "sr_4l_of", "sr_4l_sf_incl", "sr_4l_of_incl",
                     "cr_4l_btag_of", "cr_4l_btag_sf_offZ_met80", "cr_4l_sf", "cr_4l_sf_higgs",
-                    "cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_of_3b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b", "cr_4l_btag_sf_offZ_met80_3b",
+                    "cr_4l_btag_of_1b", "cr_4l_btag_of_2b", "cr_4l_btag_sf_offZ_met80_1b", "cr_4l_btag_sf_offZ_met80_2b",
                 ]
             }
 


### PR DESCRIPTION
Merge the 2b and 3+ btag bins into a 2+ bin as suggested in AN review. 

Some other minor updates including adding a new yield table to be dumped and updating the pkl file names for more consistency. 

New ref numbers for full, R2, R3: 5.31504, 4.64117, 2.61397