### PR TITLE
Update to handle RDF outputs

### DIFF
--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -9,19 +9,7 @@ from coffea import processor
 import hist
 from hist import axis
 from coffea.analysis_tools import PackedSelection
-
-from topcoffea.modules.paths import topcoffea_path
-#import topcoffea.modules.event_selection as es_tc
-#import topcoffea.modules.corrections as cor_tc
-
-from ewkcoffea.modules.paths import ewkcoffea_path as ewkcoffea_path
-#import ewkcoffea.modules.selection_wwz as es_ec
 import ewkcoffea.modules.objects_wwz as os_ec
-import ewkcoffea.modules.corrections as cor_ec
-
-from topcoffea.modules.get_param_from_jsons import GetParam
-get_tc_param = GetParam(topcoffea_path("params/params.json"))
-get_ec_param = GetParam(ewkcoffea_path("params/params.json"))
 
 
 class AnalysisProcessor(processor.ProcessorABC):
@@ -220,11 +208,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         ################### Lepton selection ####################
 
         # Get tight leptons for VVH selection, using mask from RDF
-        # These now come from RDF output
-        ele_vvh_t = ele
-        mu_vvh_t  = mu
-
-        l_vvh_t = ak.with_name(ak.concatenate([ele_vvh_t,mu_vvh_t],axis=1),'PtEtaPhiMCandidate')
+        l_vvh_t = ak.with_name(ak.concatenate([ele,mu],axis=1),'PtEtaPhiMCandidate')
         l_vvh_t = l_vvh_t[ak.argsort(l_vvh_t.pt, axis=-1,ascending=False)] # Sort by pt
         events["l_vvh_t"] = l_vvh_t
 
@@ -304,28 +288,20 @@ class AnalysisProcessor(processor.ProcessorABC):
         mljjjjcnt = ak.where(njets>=4, (l0 + j0+j1+j2+j3).mass, 0)
 
 
-        ### Btag WPs ###
-        # Eventually we should probably just take the btag jet collection from the RDF output
-        # For now handle it with a hard-to-read series of ak.where
-        btagwpl = events.nom
-        btagwpm = events.nom
-        btagwpl = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpl)
-        btagwpm = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpm)
-        btagwpl = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpl)
-        btagwpm = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpm)
-        btagwpl = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpl)
-        btagwpm = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpm)
-        btagwpl = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpl)
-        btagwpm = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpm)
+        ### Bjets ###
 
-        isBtagJetsLoose = (goodJets.btagDeepFlavB > btagwpl)
-        isBtagJetsMedium = (goodJets.btagDeepFlavB > btagwpm)
-
+        isBtagJetsLoose  = goodJets.isLooseBTag
+        isBtagJetsMedium = goodJets.isMediumBTag
+        isBtagJetsTight  = goodJets.isTightBTag
         isNotBtagJetsLoose = np.invert(isBtagJetsLoose)
-        nbtagsl = ak.num(goodJets[isBtagJetsLoose])
 
-        isNotBtagJetsMedium = np.invert(isBtagJetsMedium)
+        bjetsl = goodJets[isBtagJetsLoose]
+        bjetsm = goodJets[isBtagJetsMedium]
+        bjetst = goodJets[isBtagJetsTight]
+
+        nbtagsl = ak.num(goodJets[isBtagJetsLoose])
         nbtagsm = ak.num(goodJets[isBtagJetsMedium])
+        nbtagst = ak.num(goodJets[isBtagJetsTight])
 
 
         ######### Get variables we haven't already calculated #########
@@ -376,13 +352,11 @@ class AnalysisProcessor(processor.ProcessorABC):
         scalarptsum_lepmetfwdjets = scalarptsum_lep + met.pt + scalarptsum_jetFwd
 
         # lb pairs (i.e. always one lep, one bjet)
-        bjets = goodJets[isBtagJetsLoose]
-        bjetsm = goodJets[isBtagJetsMedium]
-        lb_pairs = ak.cartesian({"l":l_vvh_t,"j":bjets})
+        lb_pairs = ak.cartesian({"l":l_vvh_t,"j": bjetsl})
         mlb_min = ak.min((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
         mlb_max = ak.max((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
 
-        bjets_ptordered = bjets[ak.argsort(bjets.pt,axis=-1,ascending=False)]
+        bjets_ptordered = bjetsl[ak.argsort( bjetsl.pt,axis=-1,ascending=False)]
         bjets_ptordered_padded = ak.pad_none(bjets_ptordered, 2)
         b0 = bjets_ptordered_padded[:,0]
         b1 = bjets_ptordered_padded[:,1]
@@ -390,7 +364,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         mass_b0b1 = ak.where(nbtagsl>1,mass_b0b1_tmp,0)
 
         # Variables related to leading b jet score of b jets
-        bjets_bscoreordered = bjets[ak.argsort(bjets.btagDeepFlavB,axis=-1,ascending=False)]
+        bjets_bscoreordered = bjetsl[ak.argsort(bjetsl.btagDeepFlavB,axis=-1,ascending=False)]
         bjets_bscoreordered_padded = ak.pad_none(bjets_bscoreordered, 2)
         bbscore0 = bjets_bscoreordered_padded[:,0]
         bbscore1 = bjets_bscoreordered_padded[:,1]

--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -96,21 +96,6 @@ class AnalysisProcessor(processor.ProcessorABC):
             "fj0_pNetWvsQCD"  : axis.Regular(180, 0, 1, name="fj0_pNetWvsQCD", label="fj0 pNet WvsQCD"),
             "fj0_pNetZvsQCD"  : axis.Regular(180, 0, 1, name="fj0_pNetZvsQCD", label="fj0 pNet ZvsQCD"),
 
-            #"fj1_pt"  : axis.Regular(180, 0, 2000, name="fj1_pt", label="fj1 pt"),
-            #"fj1_mass"  : axis.Regular(180, 0, 250, name="fj1_mass", label="fj1 mass"),
-            #"fj1_msoftdrop"  : axis.Regular(180, 0, 250, name="fj1_msoftdrop", label="fj1 softdrop mass"),
-            #"fj1_mparticlenet"  : axis.Regular(180, 0, 250, name="fj1_mparticlenet", label="fj1 particleNet mass"),
-            #"fj1_eta" : axis.Regular(180, -5, 5, name="fj1_eta", label="fj1 eta"),
-            #"fj1_phi" : axis.Regular(180, -3.1416, 3.1416, name="fj1_phi", label="j0 phi"),
-
-            #"fj1_pNetH4qvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetH4qvsQCD", label="fj1 pNet H4qvsQCD"),
-            #"fj1_pNetHbbvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHbbvsQCD", label="fj1 pNet HbbvsQCD"),
-            #"fj1_pNetHccvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHccvsQCD", label="fj1 pNet HccvsQCD"),
-            #"fj1_pNetQCD"     : axis.Regular(180, 0, 1, name="fj1_pNetQCD",    label="fj1 pNet QCD"),
-            #"fj1_pNetTvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetTvsQCD", label="fj1 pNet TvsQCD"),
-            #"fj1_pNetWvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetWvsQCD", label="fj1 pNet WvsQCD"),
-            #"fj1_pNetZvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetZvsQCD", label="fj1 pNet ZvsQCD"),
-
             "j0central_pt"  : axis.Regular(180, 0, 250, name="j0central_pt", label="j0 pt (central jets)"), # Naming
             "j0central_eta" : axis.Regular(180, -5, 5, name="j0central_eta", label="j0 eta (central jets)"), # Naming
             "j0central_phi" : axis.Regular(180, -3.1416, 3.1416, name="j0central_phi", label="j0 phi (central jets)"), # Naming
@@ -169,6 +154,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             "mljjjjany" : axis.Regular(180, 0, 4000, name="mljjjjany", label="mljjjj of leading (in pt) lep and four central or fwd jets"),
             "mljjjjcnt" : axis.Regular(180, 0, 4000, name="mljjjjcnt", label="mljjjj of leading (in pt) lep and four central jets"),
 
+            "abs_pdgid_sum3l" : axis.Regular(20, 20, 40, name="abs_pdgid_sum", label="Sum of abs pdgId for the 3 lep"),
+
             #"ghiggs0_pt" : axis.Regular(180, 0, 1500, name="ghiggs0_pt", label="Gen higgs pt"),
             #"gvectorboson0_pt" : axis.Regular(180, 0, 1500, name="gvectorboson0_pt", label="Gen V pt"),
 
@@ -201,10 +188,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                     raise Exception(f"Error: Cannot specify hist \"{hist_to_include}\", it is not defined in the processor.")
             self._hist_lst = hist_lst # Which hists to fill
 
-        # Set the booleans
-        self._do_systematics = do_systematics # Whether to process systematic samples
-        self._skip_obj_systematics = skip_obj_systematics # Skip the JEC/JER/MET systematics (even if running with do_systematics on)
-
     @property
     def accumulator(self):
         return self._accumulator
@@ -216,53 +199,21 @@ class AnalysisProcessor(processor.ProcessorABC):
     # Main function: run on a given dataset
     def process(self, events):
 
-        # Dataset parameters
-        json_name = events.metadata["dataset"]
-
-        isData       = self._samples[json_name]["isData"]
-        #histAxisName = events.namewithyear
         histAxisName = events.shortname
         year         = events.year
         xsec         = events.xsec
-
-        # FIXME Temp fix since only R2, maybe should specify in the input cfg
-        is2022 = False
-        is2023 = False
-
-        # Era Needed for all samples
-        if isData:
-            era = self._samples[json_name]["era"]
-        else:
-            era = None
-
-
-        # Get the dataset name (used for duplicate removal) and check to make sure it is an expected name
-        # Get name for MC cases too, since "dataset" is passed to overlap removal function in all cases (though it's not actually used in the MC case)
-        dataset = json_name.split('_')[0]
-        if isData:
-            datasets = ["SingleElectron", "EGamma", "MuonEG", "DoubleMuon", "DoubleElectron", "DoubleEG","Muon"]
-            if dataset not in datasets:
-                raise Exception(f"ERROR: Unexpected dataset name for data file: {dataset}")
 
         # Initialize objects
         ele     = events.electron
         mu      = events.muon
         jets    = events.jet
-        #met     = events.MET
         met     = events.PuppiMET
         fatjets = events.fatjet
-        #fatjets = events.CorrFatJet
-        #higgs   = events.Higgs
 
         # An array of lenght events that is just 1 for each event
-        # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
         events.nom = ak.ones_like(met.pt)
-        #events.weight = events.nom
-        #events.weight = 1000* events.xsec * events.lumi * events.genWeight / events.sumw
-        #events.weight = events.baseweight
 
-        # A mask that is all True by construction
-        # Probably there's a better way to do this...
+        # A mask that is all True by construction (probably there's a better way to do this...)
         pass_through = ak.full_like(met.pt,True,dtype=bool)
 
 
@@ -287,599 +238,471 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         ######### Normalization and weights ###########
 
-        # These weights can go outside of the outside sys loop since they do not depend on pt of mu or jets
-        # We only calculate these values if not isData
+        # Weights object
         # Note: add() will generally modify up/down weights, so if these are needed for any reason after this point, we should instead pass copies to add()
-        # Note: Here we will to the weights object the SFs that do not depend on any of the forthcoming loops
         weights_obj_base = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
-        #if not isData:
-        if hasattr(events, "baseweight"):
-            events.weight = events.baseweight
-            genw_raw = events.weight
-            genw = events.weight
-            #genw_raw = 1
-            #genw = 1
-
-            # Normalize to the weight from RDF
-            #weights_obj_base.add("norm",events.weight * genw/genw_raw)
-            weights_obj_base.add("norm",events.weight)
-
-
-        ######### The rest of the processor is inside this loop over systs that affect object kinematics  ###########
-
-        obj_correction_systs = [
-            #f"CMS_scale_j_{year}",
-            #f"CMS_res_j_{year}",
-            #f"CMS_scale_met_unclustered_energy_{year}",
-        ]
-        #obj_correction_systs = append_up_down_to_sys_base(obj_correction_systs)
-
-        # If we're doing systematics and this isn't data, we will loop over the obj correction syst lst list
-        if self._do_systematics and not isData and not self._skip_obj_systematics: obj_corr_syst_var_list = ["nominal"] + obj_correction_systs
-        # Otherwise loop juse once, for nominal
-        else: obj_corr_syst_var_list = ['nominal']
-
-        # Loop over the list of systematic variations (that impact object kinematics) that we've constructed
-        for obj_corr_syst_var in obj_corr_syst_var_list:
-            # Make a copy of the base weights object, so that each time through the loop we do not double count systs
-            # In this loop over systs that impact kinematics, we will add to the weights objects the SFs that depend on the object kinematics
-            weights_obj_base_for_kinematic_syst = copy.deepcopy(weights_obj_base)
-
-
-            #################### Jets ####################
-
-            # Fat jets
-            goodfatjets = fatjets
-
-            # Clean with dr (though another option is to use jetIdx)
-            cleanedJets = os_ec.get_cleaned_collection(l_vvh_t,jets) # Clean against leps
-            cleanedJets = os_ec.get_cleaned_collection(goodfatjets,cleanedJets,drcut=0.8) # Clean against fat jets
-            jetptname = "pt_nom" if hasattr(cleanedJets, "pt_nom") else "pt"
-
-            # Selecting jets and cleaning them (already in RDF)
-            goodJets = cleanedJets[(abs(cleanedJets.eta) <= 2.4)]
-            goodJets_forward = cleanedJets[(abs(cleanedJets.eta) > 2.4)]
-
-            # Count jets
-            njets = ak.num(goodJets)
-            njets_forward = ak.num(goodJets_forward)
-            njets_tot = njets + njets_forward
-            nfatjets = ak.num(goodfatjets)
-            ht = ak.sum(goodJets.pt,axis=-1)
-
-            goodJets_ptordered = goodJets[ak.argsort(goodJets.pt,axis=-1,ascending=False)]
-            goodJets_ptordered_padded = ak.pad_none(goodJets_ptordered, 4)
-            j0 = goodJets_ptordered_padded[:,0]
-            j1 = goodJets_ptordered_padded[:,1]
-            j2 = goodJets_ptordered_padded[:,2]
-            j3 = goodJets_ptordered_padded[:,3]
-
-            goodJets_forward_ptordered = goodJets_forward[ak.argsort(goodJets_forward.pt,axis=-1,ascending=False)]
-            goodJets_forward_ptordered_padded = ak.pad_none(goodJets_forward_ptordered, 2)
-            j0forward = goodJets_forward_ptordered_padded[:,0]
-            j1forward = goodJets_forward_ptordered_padded[:,1]
-
-            goodJetsCentFwd = ak.with_name(ak.concatenate([goodJets,goodJets_forward],axis=1),'PtEtaPhiMLorentzVector')
-            goodJetsCentFwd_ptordered = goodJetsCentFwd[ak.argsort(goodJetsCentFwd.pt,axis=-1,ascending=False)]
-            goodJetsCentFwd_ptordered_padded = ak.pad_none(goodJetsCentFwd_ptordered, 4)
-            j0any = goodJetsCentFwd_ptordered_padded[:,0]
-            j1any = goodJetsCentFwd_ptordered_padded[:,1]
-            j2any = goodJetsCentFwd_ptordered_padded[:,2]
-            j3any = goodJetsCentFwd_ptordered_padded[:,3]
-
-            goodfatjets_ptordered = goodfatjets[ak.argsort(goodfatjets.pt,axis=-1,ascending=False)]
-            goodfatjets_ptordered_padded = ak.pad_none(goodfatjets_ptordered, 2)
-            fj0 = goodfatjets_ptordered_padded[:,0]
-            fj1 = goodfatjets_ptordered_padded[:,1]
-
-            scalarptsum_jetCentFwd = ak.sum(goodJetsCentFwd.pt,axis=-1)
-            scalarptsum_jetCent = ak.sum(goodJets.pt,axis=-1)
-            scalarptsum_jetFwd = ak.sum(goodJets_forward.pt,axis=-1)
-
-            mjjjany = ak.where(njets_tot>=3, (j0any+j1any+j2any).mass, 0)
-            mjjjcnt = ak.where(njets>=3, (j0+j1+j2).mass, 0)
-            mjjjjany = ak.where(njets_tot>=4, (j0any+j1any+j2any+j3any).mass, 0)
-            mjjjjcnt = ak.where(njets>=4, (j0+j1+j2+j3).mass, 0)
-
-            mljjjany = ak.where(njets_tot>=3, (l0 + j0any+j1any+j2any).mass, 0)
-            mljjjcnt = ak.where(njets>=3, (l0 + j0+j1+j2).mass, 0)
-            mljjjjany = ak.where(njets_tot>=4, (l0 + j0any+j1any+j2any+j3any).mass, 0)
-            mljjjjcnt = ak.where(njets>=4, (l0 + j0+j1+j2+j3).mass, 0)
-
-
-
-            ### Btag WPs ###
-            # Eventually we should probably just take the btag jet collection from the RDF output
-            # For now handle it with a hard-to-read series of ak.where
-            btagwpl = events.nom
-            btagwpm = events.nom
-            btagwpl = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpl)
-            btagwpm = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpm)
-            btagwpl = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpl)
-            btagwpm = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpm)
-            btagwpl = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpl)
-            btagwpm = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpm)
-            btagwpl = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpl)
-            btagwpm = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpm)
-
-            isBtagJetsLoose = (goodJets.btagDeepFlavB > btagwpl)
-            isBtagJetsMedium = (goodJets.btagDeepFlavB > btagwpm)
-
-            isNotBtagJetsLoose = np.invert(isBtagJetsLoose)
-            nbtagsl = ak.num(goodJets[isBtagJetsLoose])
-
-            isNotBtagJetsMedium = np.invert(isBtagJetsMedium)
-            nbtagsm = ak.num(goodJets[isBtagJetsMedium])
-
-
-            ######### Masks we need for the selection ##########
-
-            # Pass trigger mask
-            era_for_trg_check = era
-            if not (is2022 or is2023):
-                # Era not used for R2
-                era_for_trg_check = None
-            #pass_trg = es_tc.trg_pass_no_overlap(events,isData,dataset,str(year),dataset_dict=es_ec.dataset_dict,exclude_dict=es_ec.exclude_dict,era=era_for_trg_check)
-            #pass_trg = (pass_trg & es_ec.trg_matching(events,year))
-
-            # b jet masks
-            bmask_atleast1med_atleast2loose = ((nbtagsm>=1)&(nbtagsl>=2)) # Used for 2lss and 4l
-            bmask_exactly0loose = (nbtagsl==0) # Used for 4l WWZ SR
-            bmask_exactly0med = (nbtagsm==0) # Used for 3l CR and 2los Z CR
-            bmask_exactly1med = (nbtagsm==1) # Used for 3l SR and 2lss CR
-            bmask_exactly2med = (nbtagsm==2) # Used for CRtt
-            bmask_atleast2med = (nbtagsm>=2) # Used for 3l SR
-            bmask_atmost2med  = (nbtagsm< 3) # Used to make 2lss mutually exclusive from tttt enriched
-            bmask_atleast3med = (nbtagsm>=3) # Used for tttt enriched
-            bmask_atleast1med = (nbtagsm>=1)
-            bmask_atleast1loose = (nbtagsl>=1)
-            bmask_atleast2loose = (nbtagsl>=2)
-
-
-            ######### Get variables we haven't already calculated #########
-
-            # Replace with 0 when there are not a pair of jets
-            mjj_tmp = (j0+j1).mass
-            mass_j0centj1cent = ak.where(njets>1,mjj_tmp,0)
-
-            j0forward_eta = ak.where(njets_forward>0,j0forward.eta,0)
-
-            j0any_pt = ak.where(njets_tot>0,j0any.pt,0)
-
-            mass_j0anyj1any = ak.where(njets_tot>1,(j0any+j1any).mass,0)
-
-            mass_j0fwdj1fwd = ak.where(njets_forward>1,(j0forward+j1forward).mass,0)
-
-            # Count lepton pairs
-            ll_pairs = ak.combinations(l_vvh_t_padded, 2, fields=["l0", "l1"] )
-            sfos_mask = ak.fill_none((ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId),False)
-            n_ll_sfos = ak.num(ll_pairs[sfos_mask])
-
-            # Find the mjj of the pair of jets (central + fwd) that have the min delta R
-            jj_pairs = ak.combinations(goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
-            jj_pairs_dr = jj_pairs.j0.delta_r(jj_pairs.j1)
-            jj_pairs_idx_mindr = ak.argmin(jj_pairs_dr,axis=1,keepdims=True)
-            jj_pairs_atmindr = jj_pairs[jj_pairs_idx_mindr]
-            jj_pairs_atmindr_mjj = (jj_pairs_atmindr.j0 + jj_pairs_atmindr.j1).mass
-            jj_pairs_atmindr_mjj = ak.flatten(ak.fill_none(jj_pairs_atmindr_mjj,-999)) # Replace Nones, flatten (so e.g. [[None],[x],[y]] -> [-999,x,y])
-
-            # Find jet triplets clost to top mass
-            jetall_triplets = ak.combinations(goodJetsCentFwd_ptordered_padded, 3, fields=["j0", "j1", "j2"] )
-            jetcnt_triplets = ak.combinations(goodJets_ptordered_padded,        3, fields=["j0", "j1", "j2"] )
-            jjjall_4vec = jetall_triplets.j0 + jetall_triplets.j1 + jetall_triplets.j2
-            jjjcnt_4vec = jetcnt_triplets.j0 + jetcnt_triplets.j1 + jetcnt_triplets.j2
-            tpeak_jall_idx = ak.argmin(abs(jjjall_4vec.mass - 173),keepdims=True,axis=1)
-            tpeak_jcnt_idx = ak.argmin(abs(jjjcnt_4vec.mass - 173),keepdims=True,axis=1)
-            mjjjall_nearest_t = ak.fill_none(ak.flatten(jjjall_4vec[tpeak_jall_idx].mass),0)
-            mjjjcnt_nearest_t = ak.fill_none(ak.flatten(jjjcnt_4vec[tpeak_jcnt_idx].mass),0)
-
-            l0_pt = l0.pt
-            l0_eta = l0.eta
-            l1_pt = l1.pt
-            l1_eta = l1.eta
-            l2_pt = l2.pt
-            l2_eta = l2.eta
-            j0central_pt = j0.pt
-            j0central_eta = j0.eta
-            j0central_phi = j0.phi
-            mass_l0l1 = (l0+l1).mass
-            dr_l0l1 = l0.delta_r(l1)
-            scalarptsum_lep = ak.sum(l_vvh_t.pt,axis=-1)
-            scalarptsum_lepmet = scalarptsum_lep + met.pt
-            scalarptsum_lepmetFJ = scalarptsum_lep + met.pt + fj0.pt
-            scalarptsum_lepmetFJ10 = scalarptsum_lep + met.pt + fj0.pt + fj1.pt
-            scalarptsum_lepmetalljets = scalarptsum_lep + met.pt + scalarptsum_jetCentFwd
-            scalarptsum_lepmetcentjets = scalarptsum_lep + met.pt + scalarptsum_jetCent
-            scalarptsum_lepmetfwdjets = scalarptsum_lep + met.pt + scalarptsum_jetFwd
-
-            # lb pairs (i.e. always one lep, one bjet)
-            bjets = goodJets[isBtagJetsLoose]
-            bjetsm = goodJets[isBtagJetsMedium]
-            lb_pairs = ak.cartesian({"l":l_vvh_t,"j":bjets})
-            mlb_min = ak.min((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
-            mlb_max = ak.max((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
-
-            bjets_ptordered = bjets[ak.argsort(bjets.pt,axis=-1,ascending=False)]
-            bjets_ptordered_padded = ak.pad_none(bjets_ptordered, 2)
-            b0 = bjets_ptordered_padded[:,0]
-            b1 = bjets_ptordered_padded[:,1]
-            mass_b0b1_tmp = (b0+b1).mass
-            mass_b0b1 = ak.where(nbtagsl>1,mass_b0b1_tmp,0)
-
-            # Variables related to leading b jet score of b jets
-            bjets_bscoreordered = bjets[ak.argsort(bjets.btagDeepFlavB,axis=-1,ascending=False)]
-            bjets_bscoreordered_padded = ak.pad_none(bjets_bscoreordered, 2)
-            bbscore0 = bjets_bscoreordered_padded[:,0]
-            bbscore1 = bjets_bscoreordered_padded[:,1]
-            mass_bbscore0bbscore1 = ak.fill_none((bbscore0+bbscore1).mass,0)
-            bbscore0_bscore = ak.fill_none(bbscore0.btagDeepFlavB,0)
-            bbscore1_bscore = ak.fill_none(bbscore1.btagDeepFlavB,0)
-
-            # Variables related to leading b jet score of med b jets
-            bjetsm_bscoreordered = bjetsm[ak.argsort(bjetsm.btagDeepFlavB,axis=-1,ascending=False)]
-            bjetsm_bscoreordered_padded = ak.pad_none(bjetsm_bscoreordered, 2)
-            bmbscore0 = bjetsm_bscoreordered_padded[:,0]
-            bmbscore1 = bjetsm_bscoreordered_padded[:,1]
-            mass_bmbscore0bmbscore1 = ak.fill_none((bmbscore0+bmbscore1).mass,0)
-
-            # Variables related to leading b jet score of central jets
-            #centraljets_bscoreordered = goodJets_ptordered_padded[ak.argsort(goodJets_ptordered_padded.btagDeepFlavB,axis=-1,ascending=False)]
-            #jbscore0 = centraljets_bscoreordered[:,0]
-            #jbscore1 = centraljets_bscoreordered[:,1]
-            #mass_jbscore0jbscore1 = ak.fill_none((jbscore0+jbscore1).mass,0)
-            #jbscore0_bscore = ak.fill_none(jbscore0.btagDeepFlavB,0)
-            #jbscore1_bscore = ak.fill_none(jbscore1.btagDeepFlavB,0)
-
-            # Mjj max from any jets
-            jjCentFwd_pairs = ak.combinations( goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
-            mjj_max_any     = ak.fill_none(ak.max((jjCentFwd_pairs.j0 + jjCentFwd_pairs.j1).mass,axis=-1),0)
-            absdeta_max_any = ak.fill_none(ak.max(abs(jjCentFwd_pairs.j0.eta - jjCentFwd_pairs.j1.eta),axis=-1),0)
-
-            # Mjj max from cent jets
-            jjCent_pairs = ak.combinations(goodJets_ptordered_padded, 2, fields=["j0", "j1"] )
-            mjj_max_cent = ak.fill_none(ak.max((jjCent_pairs.j0 + jjCent_pairs.j1).mass,axis=-1),0)
-
-            # Mjj max from forward jets
-            jjFwd_pairs = ak.combinations(goodJets_forward_ptordered_padded, 2, fields=["j0", "j1"] )
-            mjj_max_fwd = ak.fill_none(ak.max((jjFwd_pairs.j0 + jjFwd_pairs.j1).mass,axis=-1),0)
-            absdeta_max_fwd = ak.fill_none(ak.max(abs(jjFwd_pairs.j0.eta - jjFwd_pairs.j1.eta),axis=-1),0)
-
-            ###
-            #if year == "2024":
-            if 1:
-                # Only for R3
-                fj0_pNetH4qvsQCD = fj0.particleNetWithMass_H4qvsQCD
-                fj0_pNetHbbvsQCD = fj0.particleNetWithMass_HbbvsQCD
-                fj0_pNetHccvsQCD = fj0.particleNetWithMass_HccvsQCD
-                fj0_pNetQCD      = fj0.particleNetWithMass_QCD
-                fj0_pNetTvsQCD   = fj0.particleNetWithMass_TvsQCD
-                fj0_pNetWvsQCD   = fj0.particleNetWithMass_WvsQCD
-                fj0_pNetZvsQCD   = fj0.particleNetWithMass_ZvsQCD
-                fj0_mparticlenet = fj0.particleNetLegacy_mass
-            else:
-                # Only for R2
-                fj0_pNetH4qvsQCD = fj0.particleNet_H4qvsQCD
-                fj0_pNetHbbvsQCD = fj0.particleNet_HbbvsQCD
-                fj0_pNetHccvsQCD = fj0.particleNet_HccvsQCD
-                fj0_pNetQCD      = fj0.particleNet_QCD
-                fj0_pNetTvsQCD   = fj0.particleNet_TvsQCD
-                fj0_pNetWvsQCD   = fj0.particleNet_WvsQCD
-                fj0_pNetZvsQCD   = fj0.particleNet_ZvsQCD
-                fj0_mparticlenet = fj0.particleNet_mass
-
-
-            # Put the variables we'll plot into a dictionary for easy access later
-            dense_variables_dict = {
-                "met" : met.pt,
-                "metphi" : met.phi,
-                "scalarptsum_lep" : scalarptsum_lep,
-                "scalarptsum_jetCentFwd" : scalarptsum_jetCentFwd,
-                "scalarptsum_jetCent" : scalarptsum_jetCent,
-                "scalarptsum_jetFwd" : scalarptsum_jetFwd,
-                "scalarptsum_lepmet" : scalarptsum_lepmet,
-                "scalarptsum_lepmetFJ" : scalarptsum_lepmetFJ,
-                "scalarptsum_lepmetFJ10" : scalarptsum_lepmetFJ10,
-                "scalarptsum_lepmetalljets" : scalarptsum_lepmetalljets,
-                "scalarptsum_lepmetcentjets" : scalarptsum_lepmetcentjets,
-                "scalarptsum_lepmetfwdjets" : scalarptsum_lepmetfwdjets,
-                "l0_pt" : l0_pt,
-                "l0_eta" : l0_eta,
-                "l1_pt" : l1_pt,
-                "l1_eta" : l1_eta,
-                "l2_pt" : l2_pt,
-                "l2_eta" : l2_eta,
-                "mass_l0l1" : mass_l0l1,
-                "dr_l0l1" : dr_l0l1,
-                "l0_iso"     : l0.pfRelIso03_all,
-                "l0_miniiso" : l0.miniPFRelIso_all,
-                "l1_iso"     : l1.pfRelIso03_all,
-                "l1_miniiso" : l1.miniPFRelIso_all,
-                "l2_iso"     : l2.pfRelIso03_all,
-                "l2_miniiso" : l2.miniPFRelIso_all,
-
-                "j0central_pt" : j0central_pt,
-                "j0central_eta" : j0central_eta,
-                "j0central_phi" : j0central_phi,
-
-                "j0forward_pt" : j0forward.pt,
-                "j0forward_eta" : j0forward_eta,
-                "j0forward_phi" : j0forward.phi,
-
-                "j0any_pt" : j0any_pt,
-                "j0any_eta" : j0any.eta,
-                "j0any_phi" : j0any.phi,
-
-                "nleps" : nleps,
-                "njets" : njets,
-                "nbtagsl" : nbtagsl,
-
-                "nleps_counts" : nleps,
-                "njets_counts" : njets,
-                "nbtagsl_counts" : nbtagsl,
-
-                "nbtagsm" : nbtagsm,
-                "nbtagsl" : nbtagsl,
-
-                "nfatjets" : nfatjets,
-                "njets_forward" : njets_forward,
-                "njets_tot" : njets_tot,
-                "fj0_pt" : fj0.pt,
-                "fj0_mass" : fj0.mass,
-                "fj0_msoftdrop" : fj0.msoftdrop,
-                "fj0_eta" : fj0.eta,
-                "fj0_phi" : fj0.phi,
-
-                #"fj1_pt" : fj1.pt,
-                #"fj1_mass" : fj1.mass,
-                #"fj1_msoftdrop" : fj1.msoftdrop,
-                #"fj1_eta" : fj1.eta,
-                #"fj1_phi" : fj1.phi,
-
-                "j0_pt" : j0.pt,
-                "j0_eta" : j0.eta,
-                "j0_phi" : j0.phi,
-
-                "dr_fj0l0" : fj0.delta_r(l0),
-                "dr_j0fwdj1fwd" : j0forward.delta_r(j1forward),
-                "dr_j0centj1cent" : j0.delta_r(j1),
-                "dr_j0anyj1any" : j0any.delta_r(j1any),
-                "absdphi_j0fwdj1fwd"   : abs(j0forward.delta_phi(j1forward)),
-                "absdphi_j0centj1cent" : abs(j0.delta_phi(j1)),
-                "absdphi_j0anyj1any"   : abs(j0any.delta_phi(j1any)),
-
-                "mass_j0centj1cent" : mass_j0centj1cent,
-                "mass_j0fwdj1fwd" : mass_j0fwdj1fwd,
-                "mass_j0anyj1any" : mass_j0anyj1any,
-
-                "mass_b0b1" : mass_b0b1,
-
-                "fj0_pNetH4qvsQCD" : fj0_pNetH4qvsQCD,
-                "fj0_pNetHbbvsQCD" : fj0_pNetHbbvsQCD,
-                "fj0_pNetHccvsQCD" : fj0_pNetHccvsQCD,
-                "fj0_pNetQCD"      : fj0_pNetQCD,
-                "fj0_pNetTvsQCD"   : fj0_pNetTvsQCD,
-                "fj0_pNetWvsQCD"   : fj0_pNetWvsQCD,
-                "fj0_pNetZvsQCD"   : fj0_pNetZvsQCD,
-                "fj0_mparticlenet" : fj0_mparticlenet,
-
-                #"fj1_pNetH4qvsQCD" : fj1_pNetH4qvsQCD,
-                #"fj1_pNetHbbvsQCD" : fj1_pNetHbbvsQCD,
-                #"fj1_pNetHccvsQCD" : fj1_pNetHccvsQCD,
-                #"fj1_pNetQCD"      : fj1_pNetQCD,
-                #"fj1_pNetTvsQCD"   : fj1_pNetTvsQCD,
-                #"fj1_pNetWvsQCD"   : fj1_pNetWvsQCD,
-                #"fj1_pNetZvsQCD"   : fj1_pNetZvsQCD,
-                #"fj1_mparticlenet" : fj1_mparticlenet,
-
-                "jj_pairs_atmindr_mjj" : jj_pairs_atmindr_mjj,
-
-                "bbscore0_bscore" : bbscore0_bscore,
-                "bbscore1_bscore" : bbscore1_bscore,
-                "mass_bbscore0bbscore1" : mass_bbscore0bbscore1,
-                "mass_bmbscore0bmbscore1" : mass_bmbscore0bmbscore1,
-
-                #"jbscore0_bscore" : jbscore0_bscore,
-                #"jbscore1_bscore" : jbscore1_bscore,
-                #"mass_jbscore0jbscore1" : mass_jbscore0jbscore1,
-
-                "mjj_max_any" : mjj_max_any,
-                "mjj_max_cent" : mjj_max_cent,
-                "mjj_max_fwd" : mjj_max_fwd,
-
-                "absdeta_max_fwd" : absdeta_max_fwd,
-                "absdeta_max_any" : absdeta_max_any,
-
-                "mjjjall_nearest_t": mjjjall_nearest_t,
-                "mjjjcnt_nearest_t": mjjjcnt_nearest_t,
-
-                "mjjjany" : mjjjany,
-                "mjjjcnt" : mjjjcnt,
-                "mjjjjany" : mjjjjany,
-                "mjjjjcnt" : mjjjjcnt,
-
-                "mljjjany" : mljjjany,
-                "mljjjcnt" : mljjjcnt,
-                "mljjjjany" : mljjjjany,
-                "mljjjjcnt" : mljjjjcnt,
-
-                #"ghiggs0_pt" : ghiggs0.pt,
-                #"gvectorboson0_pt" : gvectorboson0.pt,
-
-                "n_ll_sfos": n_ll_sfos,
-                "abs_ch_sum_3l": abs_ch_sum_3l,
-
-            }
-
-
-            ######### Store boolean masks with PackedSelection ##########
-
-            selections = PackedSelection(dtype='uint64')
-
-            # Form some useful masks for SRs
-
-            is_os = l0.pdgId*l1.pdgId<0
-            is_sf = abs(l0.pdgId) == abs(l1.pdgId)
-
-            is_2l = (nleps==2) & (l0.pt>25) & (l1.pt>15)
-            is_3l = (nleps==3) & (l0.pt>25) & (l1.pt>15) & (l2.pt>10)
-
-            is_VFJ       = (fj0_mparticlenet <= 100.) & (fj0_mparticlenet > 65)
-            is_HFJ       = (fj0_mparticlenet >  110.) & (fj0_mparticlenet <= 150.)
-            is_HFJTagHbb = (fj0_pNetHbbvsQCD > 0.98)
-
-            is_onZ = abs(mass_l0l1 - 91.1876) < 20
-
-
-            ### Inclusive selections ###
-            #filter_mask = es_ec.get_filter_flag_mask_vvh(events,year,is2022,is2023) # Get the filter flag mask
-            filter_mask = pass_through
-            lumi_mask = pass_through
-            pass_trg = pass_through
-            quality = filter_mask & lumi_mask & pass_trg # This is what we'll actually apply to the SRs
-            quality = pass_through
-            # Cut flow for quality mask
-            selections.add("all_events",     pass_through) # Just a pass through
-            selections.add("just2lep",       (nleps==2))
-            selections.add("just3lep",       (nleps==3))
-            selections.add("filter",         filter_mask)
-            selections.add("filter_grl",     filter_mask & lumi_mask)
-            selections.add("filter_grl_trg", filter_mask & lumi_mask & pass_trg)
-
-            ### 2lOS + 1FJ ###
-            selections.add("2l",                                quality & is_2l)
-            selections.add("2lOS",                              quality & is_2l & is_os)
-            selections.add("2lOSSF",                            quality & is_2l & is_os & is_sf)
-            selections.add("2lOSSF_1fj",                        quality & is_2l & is_os & is_sf & (nfatjets>=1))
-            selections.add("2lOSSF_1fjx",                       quality & is_2l & is_os & is_sf & (nfatjets==1))
-            selections.add("2lOSSF_1fjx_onZ",                   quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ)
-            selections.add("2lOSSF_1fjx_onZ_HFJ",               quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ)
-            selections.add("2lOSSF_1fjx_onZ_HFJtag",            quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb)
-            selections.add("2lOSSF_1fjx_onZ_HFJtag_nj2",        quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb & (njets_tot>=2))
-            selections.add("2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600", quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600))
-
-            ### 3l ###
-            selections.add("3l",                  quality & is_3l)
-            selections.add("3l_2j_mjj600",        quality & is_3l & (njets_tot>=2) & (mjj_max_any>600))
-            selections.add("3l_2j_mjj600_ht350",  quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (scalarptsum_lepmetalljets>350))
-            selections.add("3l_2j_mjj600_noSFOS", quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (n_ll_sfos==0))
-            selections.add("3l_2j_mjj600_ch3",    quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (abs_ch_sum_3l==3))
-
-
-            # Keep track of the ones we want to actually fill
-            cat_dict = {
-                "lep_chan_lst" : [
-
-                    "all_events",
-                    "filter",
-                    "filter_grl",
-                    "filter_grl_trg",
-                    "just2lep",
-                    "just3lep",
-
-                    ### 2l OS SF 1FJ ###
-                    "2l",
-                    "2lOS",
-                    "2lOSSF",
-                    "2lOSSF_1fj",
-                    "2lOSSF_1fjx",
-                    "2lOSSF_1fjx_onZ",
-                    "2lOSSF_1fjx_onZ_HFJ",
-                    "2lOSSF_1fjx_onZ_HFJtag",
-                    "2lOSSF_1fjx_onZ_HFJtag_nj2",
-                    "2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
-
-                    ### 3l ###
-                    "3l",
-                    "3l_2j_mjj600",
-                    "3l_2j_mjj600_ht350",
-                    "3l_2j_mjj600_noSFOS",
-                    "3l_2j_mjj600_ch3",
-                ]
-            }
-
-
-            ######### Fill histos #########
-
-            exclude_var_dict = {} # Any particular ones to skip
-
-            wgt_correction_syst_lst = []
-
-            # Set up the list of weight fluctuations to loop over
-            # For now the syst do not depend on the category, so we can figure this out outside of the filling loop
-            wgt_var_lst = ["nominal"]
-            if self._do_systematics:
-                #if not isData:
-                if not hasattr(events, "baseweight"):
-                    if (obj_corr_syst_var != "nominal"):
-                        # In this case, we are dealing with systs that change the kinematics of the objs (e.g. JES)
-                        # So we don't want to loop over up/down weight variations here
-                        wgt_var_lst = [obj_corr_syst_var]
-                    else:
-                        # Otherwise we want to loop over the up/down weight variations
-                        wgt_var_lst = wgt_var_lst + wgt_correction_syst_lst
-
-
-
-            # Loop over the hists we want to fill
-            for dense_axis_name, dense_axis_vals in dense_variables_dict.items():
-                if dense_axis_name not in self._hist_lst:
-                    #print(f"Skipping \"{dense_axis_name}\", it is not in the list of hists to include.")
-                    continue
-
-                # Loop over weight fluctuations
-                for wgt_fluct in wgt_var_lst:
-
-                    # Get the appropriate weight fluctuation
-                    if (wgt_fluct == "nominal") or (wgt_fluct in obj_corr_syst_var_list):
-                        # In the case of "nominal", no weight systematic variation is used
-                        weight = weights_obj_base_for_kinematic_syst.weight(None)
-                    else:
-                        # Otherwise get the weight from the Weights object
-                        weight = weights_obj_base_for_kinematic_syst.weight(wgt_fluct)
-
-
-                    # Loop over categories
-                    for sr_cat in cat_dict["lep_chan_lst"]:
-
-                        # Skip filling if this variable is not relevant for this selection
-                        if (dense_axis_name in exclude_var_dict) and (sr_cat in exclude_var_dict[dense_axis_name]): continue
-
-                        # If this is a counts hist, forget the weights and just fill with unit weights
-                        if dense_axis_name.endswith("_counts"): weight = events.nom
-
-                        # Make the cuts mask
-                        cuts_lst = [sr_cat]
-                        all_cuts_mask = selections.all(*cuts_lst)
-
-                        # Print info about the events
-                        #import sys
-                        #run = events.run[all_cuts_mask]
-                        #luminosityBlock = events.luminosityBlock[all_cuts_mask]
-                        #event = events.event[all_cuts_mask]
-                        #w = weight[all_cuts_mask]
-                        #if dense_axis_name == "njets":
-                        #    print("\nSTARTPRINT")
-                        #    for i,j in enumerate(w):
-                        #        out_str = f"PRINTTAG {i} {dense_axis_name} {year} {sr_cat} {event[i]} {run[i]} {luminosityBlock[i]} {w[i]}"
-                        #        print(out_str,file=sys.stderr,flush=True)
-                        #    print("ENDPRINT\n")
-                        #print("\ndense_axis_name",dense_axis_name)
-                        #print("sr_cat",sr_cat)
-                        #print("dense_axis_vals[all_cuts_mask]",dense_axis_vals[all_cuts_mask])
-                        #print("end")
-
-                        # Fill the histos
-                        axes_fill_info_dict = {
-                            dense_axis_name : ak.fill_none(dense_axis_vals[all_cuts_mask],0), # Don't like this fill_none
-                            "weight"        : ak.fill_none(weight[all_cuts_mask],0),          # Don't like this fill_none
-                            #"weight"        : ak.fill_none(events.weight[all_cuts_mask],0),          # Don't like this fill_none
-                            "process"       : histAxisName[all_cuts_mask],
-                            "category"      : sr_cat,
-                            "systematic"    : wgt_fluct,
-                            "year"          : events.year[all_cuts_mask],
-                        }
-
-                        self.accumulator[dense_axis_name].fill(**axes_fill_info_dict)
+        weights_obj_base.add("norm",events.baseweight)
+
+
+        #################### Jets ####################
+
+        # Fat jets
+        goodfatjets = fatjets
+
+        # Clean with dr (though another option is to use jetIdx)
+        cleanedJets = os_ec.get_cleaned_collection(l_vvh_t,jets) # Clean against leps
+        cleanedJets = os_ec.get_cleaned_collection(goodfatjets,cleanedJets,drcut=0.8) # Clean against fat jets
+
+        # Selecting jets and cleaning them (already in RDF)
+        goodJets = cleanedJets[(abs(cleanedJets.eta) <= 2.4)]
+        goodJets_forward = cleanedJets[(abs(cleanedJets.eta) > 2.4)]
+
+        # Count jets
+        njets = ak.num(goodJets)
+        njets_forward = ak.num(goodJets_forward)
+        njets_tot = njets + njets_forward
+        nfatjets = ak.num(goodfatjets)
+        ht = ak.sum(goodJets.pt,axis=-1)
+
+        goodJets_ptordered = goodJets[ak.argsort(goodJets.pt,axis=-1,ascending=False)]
+        goodJets_ptordered_padded = ak.pad_none(goodJets_ptordered, 4)
+        j0 = goodJets_ptordered_padded[:,0]
+        j1 = goodJets_ptordered_padded[:,1]
+        j2 = goodJets_ptordered_padded[:,2]
+        j3 = goodJets_ptordered_padded[:,3]
+
+        goodJets_forward_ptordered = goodJets_forward[ak.argsort(goodJets_forward.pt,axis=-1,ascending=False)]
+        goodJets_forward_ptordered_padded = ak.pad_none(goodJets_forward_ptordered, 2)
+        j0forward = goodJets_forward_ptordered_padded[:,0]
+        j1forward = goodJets_forward_ptordered_padded[:,1]
+
+        goodJetsCentFwd = ak.with_name(ak.concatenate([goodJets,goodJets_forward],axis=1),'PtEtaPhiMLorentzVector')
+        goodJetsCentFwd_ptordered = goodJetsCentFwd[ak.argsort(goodJetsCentFwd.pt,axis=-1,ascending=False)]
+        goodJetsCentFwd_ptordered_padded = ak.pad_none(goodJetsCentFwd_ptordered, 4)
+        j0any = goodJetsCentFwd_ptordered_padded[:,0]
+        j1any = goodJetsCentFwd_ptordered_padded[:,1]
+        j2any = goodJetsCentFwd_ptordered_padded[:,2]
+        j3any = goodJetsCentFwd_ptordered_padded[:,3]
+
+        goodfatjets_ptordered = goodfatjets[ak.argsort(goodfatjets.pt,axis=-1,ascending=False)]
+        goodfatjets_ptordered_padded = ak.pad_none(goodfatjets_ptordered, 2)
+        fj0 = goodfatjets_ptordered_padded[:,0]
+        fj1 = goodfatjets_ptordered_padded[:,1]
+
+        scalarptsum_jetCentFwd = ak.sum(goodJetsCentFwd.pt,axis=-1)
+        scalarptsum_jetCent = ak.sum(goodJets.pt,axis=-1)
+        scalarptsum_jetFwd = ak.sum(goodJets_forward.pt,axis=-1)
+
+        mjjjany  = ak.where(njets_tot>=3, (j0any+j1any+j2any).mass, 0)
+        mjjjcnt  = ak.where(njets>=3, (j0+j1+j2).mass, 0)
+        mjjjjany = ak.where(njets_tot>=4, (j0any+j1any+j2any+j3any).mass, 0)
+        mjjjjcnt = ak.where(njets>=4, (j0+j1+j2+j3).mass, 0)
+
+        mljjjany  = ak.where(njets_tot>=3, (l0 + j0any+j1any+j2any).mass, 0)
+        mljjjcnt  = ak.where(njets>=3, (l0 + j0+j1+j2).mass, 0)
+        mljjjjany = ak.where(njets_tot>=4, (l0 + j0any+j1any+j2any+j3any).mass, 0)
+        mljjjjcnt = ak.where(njets>=4, (l0 + j0+j1+j2+j3).mass, 0)
+
+
+        ### Btag WPs ###
+        # Eventually we should probably just take the btag jet collection from the RDF output
+        # For now handle it with a hard-to-read series of ak.where
+        btagwpl = events.nom
+        btagwpm = events.nom
+        btagwpl = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpl)
+        btagwpm = ak.where(events.year=="2018",get_tc_param("btag_wp_loose_UL18"),btagwpm)
+        btagwpl = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpl)
+        btagwpm = ak.where(events.year=="2017",get_tc_param("btag_wp_loose_UL17"),btagwpm)
+        btagwpl = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpl)
+        btagwpm = ak.where(events.year=="2016postVFP",get_tc_param("btag_wp_loose_UL16"),btagwpm)
+        btagwpl = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpl)
+        btagwpm = ak.where(events.year=="2016preVFP",get_tc_param("btag_wp_loose_UL16APV"),btagwpm)
+
+        isBtagJetsLoose = (goodJets.btagDeepFlavB > btagwpl)
+        isBtagJetsMedium = (goodJets.btagDeepFlavB > btagwpm)
+
+        isNotBtagJetsLoose = np.invert(isBtagJetsLoose)
+        nbtagsl = ak.num(goodJets[isBtagJetsLoose])
+
+        isNotBtagJetsMedium = np.invert(isBtagJetsMedium)
+        nbtagsm = ak.num(goodJets[isBtagJetsMedium])
+
+
+        ######### Get variables we haven't already calculated #########
+
+        # Replace with 0 when there are not a pair of jets
+        mjj_tmp = (j0+j1).mass
+        mass_j0centj1cent = ak.where(njets>1,mjj_tmp,0)
+
+        j0forward_eta = ak.where(njets_forward>0,j0forward.eta,0)
+
+        j0any_pt = ak.where(njets_tot>0,j0any.pt,0)
+
+        mass_j0anyj1any = ak.where(njets_tot>1,(j0any+j1any).mass,0)
+
+        mass_j0fwdj1fwd = ak.where(njets_forward>1,(j0forward+j1forward).mass,0)
+
+        # Count lepton pairs
+        ll_pairs = ak.combinations(l_vvh_t_padded, 2, fields=["l0", "l1"] )
+        sfos_mask = ak.fill_none((ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId),False)
+        n_ll_sfos = ak.num(ll_pairs[sfos_mask])
+
+        # Find the mjj of the pair of jets (central + fwd) that have the min delta R
+        jj_pairs = ak.combinations(goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
+        jj_pairs_dr = jj_pairs.j0.delta_r(jj_pairs.j1)
+        jj_pairs_idx_mindr = ak.argmin(jj_pairs_dr,axis=1,keepdims=True)
+        jj_pairs_atmindr = jj_pairs[jj_pairs_idx_mindr]
+        jj_pairs_atmindr_mjj = (jj_pairs_atmindr.j0 + jj_pairs_atmindr.j1).mass
+        jj_pairs_atmindr_mjj = ak.flatten(ak.fill_none(jj_pairs_atmindr_mjj,-999)) # Replace Nones, flatten (so e.g. [[None],[x],[y]] -> [-999,x,y])
+
+        # Find jet triplets clost to top mass
+        jetall_triplets = ak.combinations(goodJetsCentFwd_ptordered_padded, 3, fields=["j0", "j1", "j2"] )
+        jetcnt_triplets = ak.combinations(goodJets_ptordered_padded,        3, fields=["j0", "j1", "j2"] )
+        jjjall_4vec = jetall_triplets.j0 + jetall_triplets.j1 + jetall_triplets.j2
+        jjjcnt_4vec = jetcnt_triplets.j0 + jetcnt_triplets.j1 + jetcnt_triplets.j2
+        tpeak_jall_idx = ak.argmin(abs(jjjall_4vec.mass - 173),keepdims=True,axis=1)
+        tpeak_jcnt_idx = ak.argmin(abs(jjjcnt_4vec.mass - 173),keepdims=True,axis=1)
+        mjjjall_nearest_t = ak.fill_none(ak.flatten(jjjall_4vec[tpeak_jall_idx].mass),0)
+        mjjjcnt_nearest_t = ak.fill_none(ak.flatten(jjjcnt_4vec[tpeak_jcnt_idx].mass),0)
+
+        mass_l0l1 = (l0+l1).mass
+        dr_l0l1 = l0.delta_r(l1)
+        scalarptsum_lep = ak.sum(l_vvh_t.pt,axis=-1)
+        scalarptsum_lepmet = scalarptsum_lep + met.pt
+        scalarptsum_lepmetFJ = scalarptsum_lep + met.pt + fj0.pt
+        scalarptsum_lepmetFJ10 = scalarptsum_lep + met.pt + fj0.pt + fj1.pt
+        scalarptsum_lepmetalljets = scalarptsum_lep + met.pt + scalarptsum_jetCentFwd
+        scalarptsum_lepmetcentjets = scalarptsum_lep + met.pt + scalarptsum_jetCent
+        scalarptsum_lepmetfwdjets = scalarptsum_lep + met.pt + scalarptsum_jetFwd
+
+        # lb pairs (i.e. always one lep, one bjet)
+        bjets = goodJets[isBtagJetsLoose]
+        bjetsm = goodJets[isBtagJetsMedium]
+        lb_pairs = ak.cartesian({"l":l_vvh_t,"j":bjets})
+        mlb_min = ak.min((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
+        mlb_max = ak.max((lb_pairs["l"] + lb_pairs["j"]).mass,axis=-1)
+
+        bjets_ptordered = bjets[ak.argsort(bjets.pt,axis=-1,ascending=False)]
+        bjets_ptordered_padded = ak.pad_none(bjets_ptordered, 2)
+        b0 = bjets_ptordered_padded[:,0]
+        b1 = bjets_ptordered_padded[:,1]
+        mass_b0b1_tmp = (b0+b1).mass
+        mass_b0b1 = ak.where(nbtagsl>1,mass_b0b1_tmp,0)
+
+        # Variables related to leading b jet score of b jets
+        bjets_bscoreordered = bjets[ak.argsort(bjets.btagDeepFlavB,axis=-1,ascending=False)]
+        bjets_bscoreordered_padded = ak.pad_none(bjets_bscoreordered, 2)
+        bbscore0 = bjets_bscoreordered_padded[:,0]
+        bbscore1 = bjets_bscoreordered_padded[:,1]
+        mass_bbscore0bbscore1 = ak.fill_none((bbscore0+bbscore1).mass,0)
+        bbscore0_bscore = ak.fill_none(bbscore0.btagDeepFlavB,0)
+        bbscore1_bscore = ak.fill_none(bbscore1.btagDeepFlavB,0)
+
+        # Variables related to leading b jet score of med b jets
+        bjetsm_bscoreordered = bjetsm[ak.argsort(bjetsm.btagDeepFlavB,axis=-1,ascending=False)]
+        bjetsm_bscoreordered_padded = ak.pad_none(bjetsm_bscoreordered, 2)
+        bmbscore0 = bjetsm_bscoreordered_padded[:,0]
+        bmbscore1 = bjetsm_bscoreordered_padded[:,1]
+        mass_bmbscore0bmbscore1 = ak.fill_none((bmbscore0+bmbscore1).mass,0)
+
+        # Variables related to leading b jet score of central jets
+        #centraljets_bscoreordered = goodJets_ptordered_padded[ak.argsort(goodJets_ptordered_padded.btagDeepFlavB,axis=-1,ascending=False)]
+        #jbscore0 = centraljets_bscoreordered[:,0]
+        #jbscore1 = centraljets_bscoreordered[:,1]
+        #mass_jbscore0jbscore1 = ak.fill_none((jbscore0+jbscore1).mass,0)
+        #jbscore0_bscore = ak.fill_none(jbscore0.btagDeepFlavB,0)
+        #jbscore1_bscore = ak.fill_none(jbscore1.btagDeepFlavB,0)
+
+        # Mjj max from any jets
+        jjCentFwd_pairs = ak.combinations( goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
+        mjj_max_any     = ak.fill_none(ak.max((jjCentFwd_pairs.j0 + jjCentFwd_pairs.j1).mass,axis=-1),0)
+        absdeta_max_any = ak.fill_none(ak.max(abs(jjCentFwd_pairs.j0.eta - jjCentFwd_pairs.j1.eta),axis=-1),0)
+
+        # Mjj max from cent jets
+        jjCent_pairs = ak.combinations(goodJets_ptordered_padded, 2, fields=["j0", "j1"] )
+        mjj_max_cent = ak.fill_none(ak.max((jjCent_pairs.j0 + jjCent_pairs.j1).mass,axis=-1),0)
+
+        # Mjj max from forward jets
+        jjFwd_pairs = ak.combinations(goodJets_forward_ptordered_padded, 2, fields=["j0", "j1"] )
+        mjj_max_fwd = ak.fill_none(ak.max((jjFwd_pairs.j0 + jjFwd_pairs.j1).mass,axis=-1),0)
+        absdeta_max_fwd = ak.fill_none(ak.max(abs(jjFwd_pairs.j0.eta - jjFwd_pairs.j1.eta),axis=-1),0)
+
+        fj0_pNetH4qvsQCD = fj0.particleNetWithMass_H4qvsQCD
+        fj0_pNetHbbvsQCD = fj0.particleNetWithMass_HbbvsQCD
+        fj0_pNetHccvsQCD = fj0.particleNetWithMass_HccvsQCD
+        fj0_pNetQCD      = fj0.particleNetWithMass_QCD
+        fj0_pNetTvsQCD   = fj0.particleNetWithMass_TvsQCD
+        fj0_pNetWvsQCD   = fj0.particleNetWithMass_WvsQCD
+        fj0_pNetZvsQCD   = fj0.particleNetWithMass_ZvsQCD
+        fj0_mparticlenet = fj0.particleNetLegacy_mass
+
+
+        # Put the variables we'll plot into a dictionary for easy access later
+        dense_variables_dict = {
+            "met" : met.pt,
+            "metphi" : met.phi,
+            "scalarptsum_lep" : scalarptsum_lep,
+            "scalarptsum_jetCentFwd" : scalarptsum_jetCentFwd,
+            "scalarptsum_jetCent" : scalarptsum_jetCent,
+            "scalarptsum_jetFwd" : scalarptsum_jetFwd,
+            "scalarptsum_lepmet" : scalarptsum_lepmet,
+            "scalarptsum_lepmetFJ" : scalarptsum_lepmetFJ,
+            "scalarptsum_lepmetFJ10" : scalarptsum_lepmetFJ10,
+            "scalarptsum_lepmetalljets" : scalarptsum_lepmetalljets,
+            "scalarptsum_lepmetcentjets" : scalarptsum_lepmetcentjets,
+            "scalarptsum_lepmetfwdjets" : scalarptsum_lepmetfwdjets,
+            "l0_pt"  : l0.pt,
+            "l0_eta" : l0.eta,
+            "l1_pt"  : l1.pt,
+            "l1_eta" : l1.eta,
+            "l2_pt"  : l2.pt,
+            "l2_eta" : l2.eta,
+            "mass_l0l1" : mass_l0l1,
+            "dr_l0l1" : dr_l0l1,
+            "l0_iso"     : l0.pfRelIso03_all,
+            "l0_miniiso" : l0.miniPFRelIso_all,
+            "l1_iso"     : l1.pfRelIso03_all,
+            "l1_miniiso" : l1.miniPFRelIso_all,
+            "l2_iso"     : l2.pfRelIso03_all,
+            "l2_miniiso" : l2.miniPFRelIso_all,
+
+            "j0central_pt"  : j0.pt,
+            "j0central_eta" : j0.eta,
+            "j0central_phi" : j0.phi,
+
+            "j0forward_pt"  : j0forward.pt,
+            "j0forward_eta" : j0forward_eta,
+            "j0forward_phi" : j0forward.phi,
+
+            "j0any_pt"  : j0any_pt,
+            "j0any_eta" : j0any.eta,
+            "j0any_phi" : j0any.phi,
+
+            "nleps" : nleps,
+            "njets" : njets,
+            "nbtagsl" : nbtagsl,
+
+            "nleps_counts" : nleps,
+            "njets_counts" : njets,
+            "nbtagsl_counts" : nbtagsl,
+
+            "nbtagsm" : nbtagsm,
+            "nbtagsl" : nbtagsl,
+
+            "nfatjets" : nfatjets,
+            "njets_forward" : njets_forward,
+            "njets_tot" : njets_tot,
+            "fj0_pt" : fj0.pt,
+            "fj0_mass" : fj0.mass,
+            "fj0_msoftdrop" : fj0.msoftdrop,
+            "fj0_eta" : fj0.eta,
+            "fj0_phi" : fj0.phi,
+
+            "j0_pt" : j0.pt,
+            "j0_eta" : j0.eta,
+            "j0_phi" : j0.phi,
+
+            "dr_fj0l0" : fj0.delta_r(l0),
+            "dr_j0fwdj1fwd" : j0forward.delta_r(j1forward),
+            "dr_j0centj1cent" : j0.delta_r(j1),
+            "dr_j0anyj1any" : j0any.delta_r(j1any),
+            "absdphi_j0fwdj1fwd"   : abs(j0forward.delta_phi(j1forward)),
+            "absdphi_j0centj1cent" : abs(j0.delta_phi(j1)),
+            "absdphi_j0anyj1any"   : abs(j0any.delta_phi(j1any)),
+
+            "mass_j0centj1cent" : mass_j0centj1cent,
+            "mass_j0fwdj1fwd" : mass_j0fwdj1fwd,
+            "mass_j0anyj1any" : mass_j0anyj1any,
+
+            "mass_b0b1" : mass_b0b1,
+
+            "fj0_pNetH4qvsQCD" : fj0_pNetH4qvsQCD,
+            "fj0_pNetHbbvsQCD" : fj0_pNetHbbvsQCD,
+            "fj0_pNetHccvsQCD" : fj0_pNetHccvsQCD,
+            "fj0_pNetQCD"      : fj0_pNetQCD,
+            "fj0_pNetTvsQCD"   : fj0_pNetTvsQCD,
+            "fj0_pNetWvsQCD"   : fj0_pNetWvsQCD,
+            "fj0_pNetZvsQCD"   : fj0_pNetZvsQCD,
+            "fj0_mparticlenet" : fj0_mparticlenet,
+
+            "jj_pairs_atmindr_mjj" : jj_pairs_atmindr_mjj,
+
+            "bbscore0_bscore" : bbscore0_bscore,
+            "bbscore1_bscore" : bbscore1_bscore,
+            "mass_bbscore0bbscore1" : mass_bbscore0bbscore1,
+            "mass_bmbscore0bmbscore1" : mass_bmbscore0bmbscore1,
+
+            #"jbscore0_bscore" : jbscore0_bscore,
+            #"jbscore1_bscore" : jbscore1_bscore,
+            #"mass_jbscore0jbscore1" : mass_jbscore0jbscore1,
+
+            "mjj_max_any" : mjj_max_any,
+            "mjj_max_cent" : mjj_max_cent,
+            "mjj_max_fwd" : mjj_max_fwd,
+
+            "absdeta_max_fwd" : absdeta_max_fwd,
+            "absdeta_max_any" : absdeta_max_any,
+
+            "mjjjall_nearest_t": mjjjall_nearest_t,
+            "mjjjcnt_nearest_t": mjjjcnt_nearest_t,
+
+            "mjjjany" : mjjjany,
+            "mjjjcnt" : mjjjcnt,
+            "mjjjjany" : mjjjjany,
+            "mjjjjcnt" : mjjjjcnt,
+
+            "mljjjany" : mljjjany,
+            "mljjjcnt" : mljjjcnt,
+            "mljjjjany" : mljjjjany,
+            "mljjjjcnt" : mljjjjcnt,
+
+            #"ghiggs0_pt" : ghiggs0.pt,
+            #"gvectorboson0_pt" : gvectorboson0.pt,
+
+            "n_ll_sfos": n_ll_sfos,
+            "abs_ch_sum_3l": abs_ch_sum_3l,
+            "abs_pdgid_sum3l": abs(l0.pdgId) + abs(l1.pdgId) + abs(l2.pdgId),
+
+        }
+
+
+        ######### Store boolean masks with PackedSelection ##########
+
+        selections = PackedSelection(dtype='uint64')
+
+        # Form some useful masks for SRs
+
+        is_os = l0.pdgId*l1.pdgId<0
+        is_sf = abs(l0.pdgId) == abs(l1.pdgId)
+
+        is_2l = (nleps==2) & (l0.pt>25) & (l1.pt>15)
+        is_3l = (nleps==3) & (l0.pt>25) & (l1.pt>15) & (l2.pt>10)
+
+        is_VFJ       = (fj0_mparticlenet <= 100.) & (fj0_mparticlenet > 65)
+        is_HFJ       = (fj0_mparticlenet >  110.) & (fj0_mparticlenet <= 150.)
+        is_HFJTagHbb = (fj0_pNetHbbvsQCD > 0.98)
+
+        is_onZ = abs(mass_l0l1 - 91.1876) < 20
+
+        ### 2lOS + 1FJ ###
+        selections.add("2l",                                      is_2l)
+        selections.add("2lOS",                                    is_2l & is_os)
+        selections.add("2lOSSF",                                  is_2l & is_os & is_sf)
+        selections.add("2lOSSF_1fj",                              is_2l & is_os & is_sf & (nfatjets>=1))
+        selections.add("2lOSSF_1fjx",                             is_2l & is_os & is_sf & (nfatjets==1))
+        selections.add("2lOSSF_1fjx_HFJ",                         is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ)
+        selections.add("2lOSSF_1fjx_HFJtag",                      is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb)
+        selections.add("2lOSSF_1fjx_HFJtag_nj2",                  is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb & (njets_tot>=2))
+        selections.add("2lOSSF_1fjx_HFJtag_nj2_mjj600",           is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600))
+        selections.add("2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0",      is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600) & (nbtagsm==0))
+        selections.add("2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0_onZ",  is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600) & (nbtagsm==0) & is_onZ)
+        selections.add("2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0_offZ", is_2l & is_os & is_sf & (nfatjets==1) & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600) & (nbtagsm==0) & ~is_onZ)
+
+        ### 3l ###
+        selections.add("3l",                           is_3l)
+        selections.add("3l_2j_mjj400",                 is_3l & (njets_tot>=2) & (mjj_max_any>400))
+        selections.add("3l_2j_mjj400_noSFOS",          is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos==0))
+        selections.add("3l_2j_mjj400_noSFOS_b0p4",     is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos==0) & (bbscore0_bscore<0.4))
+        selections.add("3l_2j_mjj400_noSFOS_b0p4_ch1", is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos==0) & (bbscore0_bscore<0.4) & (abs_ch_sum_3l==1))
+        selections.add("3l_2j_mjj400_noSFOS_b0p4_ch3", is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos==0) & (bbscore0_bscore<0.4) & (abs_ch_sum_3l==3))
+        selections.add("3l_2j_mjj400_SFOS",            is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos>0))
+        selections.add("3l_2j_mjj400_SFOS_jf0pt50",    is_3l & (njets_tot>=2) & (mjj_max_any>400) & (n_ll_sfos>0) & (j0forward.pt>50))
+
+        # Keep track of the ones we want to actually fill
+        cat_dict = {
+            "lep_chan_lst" : [
+
+                ### 2l OS SF 1FJ ###
+                "2l",
+                "2lOS",
+                "2lOSSF",
+                "2lOSSF_1fj",
+                "2lOSSF_1fjx",
+                "2lOSSF_1fjx_HFJ",
+                "2lOSSF_1fjx_HFJtag",
+                "2lOSSF_1fjx_HFJtag_nj2",
+                "2lOSSF_1fjx_HFJtag_nj2_mjj600",
+                "2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0",
+                "2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0_onZ",
+                "2lOSSF_1fjx_HFJtag_nj2_mjj600_nbm0_offZ",
+
+                ### 3l ###
+                "3l",
+                "3l_2j_mjj400",
+                "3l_2j_mjj400_noSFOS",
+                "3l_2j_mjj400_noSFOS_b0p4",
+                "3l_2j_mjj400_noSFOS_b0p4_ch1",
+                "3l_2j_mjj400_noSFOS_b0p4_ch3",
+                "3l_2j_mjj400_SFOS",
+                "3l_2j_mjj400_SFOS_jf0pt50",
+            ]
+        }
+
+
+        ######### Fill histos #########
+
+        wgt_correction_syst_lst = []
+
+        # Set up the list of weight fluctuations to loop over
+        # For now the syst do not depend on the category, so we can figure this out outside of the filling loop
+        wgt_var_lst = ["nominal"]
+
+        # Loop over the hists we want to fill
+        for dense_axis_name, dense_axis_vals in dense_variables_dict.items():
+            if dense_axis_name not in self._hist_lst:
+                #print(f"Skipping \"{dense_axis_name}\", it is not in the list of hists to include.")
+                continue
+
+            # Loop over weight fluctuations
+            for wgt_fluct in wgt_var_lst:
+
+                # Get the appropriate weight fluctuation
+                if (wgt_fluct == "nominal"):
+                    # In the case of "nominal", no weight systematic variation is used
+                    weight = weights_obj_base.weight(None)
+                else:
+                    # Otherwise get the weight from the Weights object
+                    weight = weights_obj_base.weight(wgt_fluct)
+
+
+                # Loop over categories
+                for sr_cat in cat_dict["lep_chan_lst"]:
+
+                    # If this is a counts hist, forget the weights and just fill with unit weights
+                    if dense_axis_name.endswith("_counts"): weight = events.nom
+
+                    # Make the cuts mask
+                    cuts_lst = [sr_cat]
+                    all_cuts_mask = selections.all(*cuts_lst)
+
+                    # Print info about the events
+                    #import sys
+                    #run = events.run[all_cuts_mask]
+                    #luminosityBlock = events.luminosityBlock[all_cuts_mask]
+                    #event = events.event[all_cuts_mask]
+                    #w = weight[all_cuts_mask]
+                    #if dense_axis_name == "njets":
+                    #    print("\nSTARTPRINT")
+                    #    for i,j in enumerate(w):
+                    #        out_str = f"PRINTTAG {i} {dense_axis_name} {year} {sr_cat} {event[i]} {run[i]} {luminosityBlock[i]} {w[i]}"
+                    #        print(out_str,file=sys.stderr,flush=True)
+                    #    print("ENDPRINT\n")
+                    #print("\ndense_axis_name",dense_axis_name)
+                    #print("sr_cat",sr_cat)
+                    #print("dense_axis_vals[all_cuts_mask]",dense_axis_vals[all_cuts_mask])
+                    #print("end")
+
+                    # Fill the histos
+                    axes_fill_info_dict = {
+                        dense_axis_name : ak.fill_none(dense_axis_vals[all_cuts_mask],0), # Don't like this fill_none
+                        "weight"        : ak.fill_none(weight[all_cuts_mask],0),          # Don't like this fill_none
+                        "process"       : histAxisName[all_cuts_mask],
+                        "category"      : sr_cat,
+                        "systematic"    : wgt_fluct,
+                        "year"          : events.year[all_cuts_mask],
+                    }
+
+                    self.accumulator[dense_axis_name].fill(**axes_fill_info_dict)
 
         return self.accumulator
 

--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -53,7 +53,14 @@ class AnalysisProcessor(processor.ProcessorABC):
             "l2_pt"  : axis.Regular(180, 0, 1000, name="l2_pt", label="l2 pt"),
             "l2_eta"  : axis.Regular(180, -3,3, name="l2_eta", label="l2 eta"),
 
-            "mass_l0l1"  : axis.Regular(180, 0,1000, name="mass_l0l1", label="mll of leading two leptons"),
+            "l0_iso"     : axis.Regular(180, 0,0.2, name="l0_iso", label="l0 pfRelIso03_all"),
+            "l0_miniiso" : axis.Regular(180, 0,0.2, name="l0_miniiso", label="l0 miniPFRelIso_all"),
+            "l1_iso"     : axis.Regular(180, 0,0.2, name="l1_iso", label="l1 pfRelIso03_all"),
+            "l1_miniiso" : axis.Regular(180, 0,0.2, name="l1_miniiso", label="l1 miniPFRelIso_all"),
+            "l2_iso"     : axis.Regular(180, 0,0.2, name="l2_iso", label="l2 pfRelIso03_all"),
+            "l2_miniiso" : axis.Regular(180, 0,0.2, name="l2_miniiso", label="l2 miniPFRelIso_all"),
+
+            "mass_l0l1"  : axis.Regular(180, 0,500, name="mass_l0l1", label="mll of leading two leptons"),
             "dr_l0l1" : axis.Regular(180, 0, 6, name="dr_l0l1", label="dr between leading two leptons"),
 
             #"mlb_min" : axis.Regular(180, 0, 300, name="mlb_min",  label="min mass(b+l)"),
@@ -71,6 +78,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             "njets_forward"   : axis.Regular(8, 0, 8, name="njets_forward",   label="Jet multiplicity (forward)"),
             "njets_tot"   : axis.Regular(8, 0, 8, name="njets_tot",   label="Jet multiplicity (central and forward)"),
 
+            "n_ll_sfos"   : axis.Regular(5, 0, 5, name="n_ll_sfos",   label="Number of SF OS lepton pairs"),
+            "abs_ch_sum_3l" : axis.Regular(4, 0, 4, name="abs_ch_sum_3l",   label="Abs sum of charges of the 3l"),
+
             "fj0_pt"  : axis.Regular(180, 0, 2000, name="fj0_pt", label="fj0 pt"),
             "fj0_mass"  : axis.Regular(180, 0, 250, name="fj0_mass", label="fj0 mass"),
             "fj0_msoftdrop"  : axis.Regular(180, 0, 250, name="fj0_msoftdrop", label="fj0 softdrop mass"),
@@ -86,20 +96,20 @@ class AnalysisProcessor(processor.ProcessorABC):
             "fj0_pNetWvsQCD"  : axis.Regular(180, 0, 1, name="fj0_pNetWvsQCD", label="fj0 pNet WvsQCD"),
             "fj0_pNetZvsQCD"  : axis.Regular(180, 0, 1, name="fj0_pNetZvsQCD", label="fj0 pNet ZvsQCD"),
 
-            "fj1_pt"  : axis.Regular(180, 0, 2000, name="fj1_pt", label="fj1 pt"),
-            "fj1_mass"  : axis.Regular(180, 0, 250, name="fj1_mass", label="fj1 mass"),
-            "fj1_msoftdrop"  : axis.Regular(180, 0, 250, name="fj1_msoftdrop", label="fj1 softdrop mass"),
-            "fj1_mparticlenet"  : axis.Regular(180, 0, 250, name="fj1_mparticlenet", label="fj1 particleNet mass"),
-            "fj1_eta" : axis.Regular(180, -5, 5, name="fj1_eta", label="fj1 eta"),
-            "fj1_phi" : axis.Regular(180, -3.1416, 3.1416, name="fj1_phi", label="j0 phi"),
+            #"fj1_pt"  : axis.Regular(180, 0, 2000, name="fj1_pt", label="fj1 pt"),
+            #"fj1_mass"  : axis.Regular(180, 0, 250, name="fj1_mass", label="fj1 mass"),
+            #"fj1_msoftdrop"  : axis.Regular(180, 0, 250, name="fj1_msoftdrop", label="fj1 softdrop mass"),
+            #"fj1_mparticlenet"  : axis.Regular(180, 0, 250, name="fj1_mparticlenet", label="fj1 particleNet mass"),
+            #"fj1_eta" : axis.Regular(180, -5, 5, name="fj1_eta", label="fj1 eta"),
+            #"fj1_phi" : axis.Regular(180, -3.1416, 3.1416, name="fj1_phi", label="j0 phi"),
 
-            "fj1_pNetH4qvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetH4qvsQCD", label="fj1 pNet H4qvsQCD"),
-            "fj1_pNetHbbvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHbbvsQCD", label="fj1 pNet HbbvsQCD"),
-            "fj1_pNetHccvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHccvsQCD", label="fj1 pNet HccvsQCD"),
-            "fj1_pNetQCD"     : axis.Regular(180, 0, 1, name="fj1_pNetQCD",    label="fj1 pNet QCD"),
-            "fj1_pNetTvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetTvsQCD", label="fj1 pNet TvsQCD"),
-            "fj1_pNetWvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetWvsQCD", label="fj1 pNet WvsQCD"),
-            "fj1_pNetZvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetZvsQCD", label="fj1 pNet ZvsQCD"),
+            #"fj1_pNetH4qvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetH4qvsQCD", label="fj1 pNet H4qvsQCD"),
+            #"fj1_pNetHbbvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHbbvsQCD", label="fj1 pNet HbbvsQCD"),
+            #"fj1_pNetHccvsQCD": axis.Regular(180, 0, 1, name="fj1_pNetHccvsQCD", label="fj1 pNet HccvsQCD"),
+            #"fj1_pNetQCD"     : axis.Regular(180, 0, 1, name="fj1_pNetQCD",    label="fj1 pNet QCD"),
+            #"fj1_pNetTvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetTvsQCD", label="fj1 pNet TvsQCD"),
+            #"fj1_pNetWvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetWvsQCD", label="fj1 pNet WvsQCD"),
+            #"fj1_pNetZvsQCD"  : axis.Regular(180, 0, 1, name="fj1_pNetZvsQCD", label="fj1 pNet ZvsQCD"),
 
             "j0central_pt"  : axis.Regular(180, 0, 250, name="j0central_pt", label="j0 pt (central jets)"), # Naming
             "j0central_eta" : axis.Regular(180, -5, 5, name="j0central_eta", label="j0 eta (central jets)"), # Naming
@@ -141,6 +151,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             "mjj_max_cent" : axis.Regular(180, 0, 250, name="mjj_max_cent", label="Leading mjj of pair of non-forward jets"),
             "mjj_max_fwd" : axis.Regular(180, 0, 2500, name="mjj_max_fwd", label="Leading mjj of pair of forward jets"),
             "mjj_max_any" : axis.Regular(180, 0, 1500, name="mjj_max_any", label="Leading mjj of pair of any (central or fwd) jets"),
+            "absdeta_max_fwd" : axis.Regular(180, 0, 10, name="absdeta_max_fwd", label="Largest abs(delta eta) of pair of forward jets"),
+            "absdeta_max_any" : axis.Regular(180, 0, 10, name="absdeta_max_any", label="Largest abs(delta eta) of pair of any (central or fwd) jets"),
 
             "jj_pairs_atmindr_mjj" : axis.Regular(180, 0, 1000, name="jj_pairs_atmindr_mjj", label="jj_pairs_atmindr_mjj"),
 
@@ -157,6 +169,9 @@ class AnalysisProcessor(processor.ProcessorABC):
             "mljjjjany" : axis.Regular(180, 0, 4000, name="mljjjjany", label="mljjjj of leading (in pt) lep and four central or fwd jets"),
             "mljjjjcnt" : axis.Regular(180, 0, 4000, name="mljjjjcnt", label="mljjjj of leading (in pt) lep and four central jets"),
 
+            #"ghiggs0_pt" : axis.Regular(180, 0, 1500, name="ghiggs0_pt", label="Gen higgs pt"),
+            #"gvectorboson0_pt" : axis.Regular(180, 0, 1500, name="gvectorboson0_pt", label="Gen V pt"),
+
         }
 
         # Add histograms to dictionary that will be passed on to dict_accumulator
@@ -170,12 +185,6 @@ class AnalysisProcessor(processor.ProcessorABC):
                 storage="weight", # Keeps track of sumw2
                 name="Counts",
             )
-
-        # Adding list accumulators for BDT output variables and weights
-        if siphon_bdt_data:
-            list_output_names = []
-            for list_output_name in list_output_names:
-                dout[list_output_name] = processor.list_accumulator([])
 
         # Set the accumulator
         self._accumulator = processor.dict_accumulator(dout)
@@ -194,8 +203,6 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Set the booleans
         self._do_systematics = do_systematics # Whether to process systematic samples
         self._skip_obj_systematics = skip_obj_systematics # Skip the JEC/JER/MET systematics (even if running with do_systematics on)
-        self._skip_signal_regions = skip_signal_regions # Whether to skip the SR categories
-        self._skip_control_regions = skip_control_regions # Whether to skip the CR categories
 
     @property
     def accumulator(self):
@@ -250,6 +257,10 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
         events.nom = ak.ones_like(met.pt)
 
+        # A mask that is all True by construction
+        # Probably there's a better way to do this...
+        pass_through = ak.full_like(met.pt,True,dtype=bool)
+
 
         ################### Lepton selection ####################
 
@@ -267,6 +278,7 @@ class AnalysisProcessor(processor.ProcessorABC):
         l1 = l_vvh_t_padded[:,1]
         l2 = l_vvh_t_padded[:,2]
         nleps = ak.num(l_vvh_t)
+        abs_ch_sum_3l = abs(l0.charge + l1.charge + l2.charge)
 
 
         ######### Normalization and weights ###########
@@ -277,11 +289,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Note: Here we will to the weights object the SFs that do not depend on any of the forthcoming loops
         weights_obj_base = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
         if not isData:
-            #if ak.any(events["LHEReweightingWeight"]):
-            #    genw = events["LHEReweightingWeight"][:,60]
-            #else:
-            #    genw = events["genWeight"]
-            #genw_raw = events["genWeight"]
+            #genw_raw = events.weight
+            #genw = events.weight
             genw_raw = 1
             genw = 1
 
@@ -313,19 +322,12 @@ class AnalysisProcessor(processor.ProcessorABC):
             #################### Jets ####################
 
             # Fat jets
-            goodfatjets = fatjets[os_ec.is_good_fatjet(fatjets)]
-            goodfatjets = os_ec.get_cleaned_collection(l_vvh_t,goodfatjets,drcut=0.8)
+            goodfatjets = fatjets
 
             # Clean with dr (though another option is to use jetIdx)
             cleanedJets = os_ec.get_cleaned_collection(l_vvh_t,jets) # Clean against leps
             cleanedJets = os_ec.get_cleaned_collection(goodfatjets,cleanedJets,drcut=0.8) # Clean against fat jets
             jetptname = "pt_nom" if hasattr(cleanedJets, "pt_nom") else "pt"
-
-            # Jet Veto Maps
-            # Removes events that have ANY jet in a specific eta-phi space (not required for Run 2)
-            # Zero is passing the veto map, so Run 2 will be assigned an array of length events with all zeros
-            veto_map_array = cor_ec.ApplyJetVetoMaps(cleanedJets, year) if (is2022 or is2023) else ak.zeros_like(met.pt)
-            veto_map_mask = (veto_map_array == 0)
 
             # Selecting jets and cleaning them (already in RDF)
             goodJets = cleanedJets[(abs(cleanedJets.eta) <= 2.4)]
@@ -441,6 +443,10 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             mass_j0fwdj1fwd = ak.where(njets_forward>1,(j0forward+j1forward).mass,0)
 
+            # Count lepton pairs
+            ll_pairs = ak.combinations(l_vvh_t_padded, 2, fields=["l0", "l1"] )
+            sfos_mask = ak.fill_none((ll_pairs.l0.pdgId == -ll_pairs.l1.pdgId),False)
+            n_ll_sfos = ak.num(ll_pairs[sfos_mask])
 
             # Find the mjj of the pair of jets (central + fwd) that have the min delta R
             jj_pairs = ak.combinations(goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
@@ -455,8 +461,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             jetcnt_triplets = ak.combinations(goodJets_ptordered_padded,        3, fields=["j0", "j1", "j2"] )
             jjjall_4vec = jetall_triplets.j0 + jetall_triplets.j1 + jetall_triplets.j2
             jjjcnt_4vec = jetcnt_triplets.j0 + jetcnt_triplets.j1 + jetcnt_triplets.j2
-            tpeak_jall_idx = ak.argmin(abs(jjjall_4vec.mass - 273),keepdims=True,axis=1)
-            tpeak_jcnt_idx = ak.argmin(abs(jjjcnt_4vec.mass - 273),keepdims=True,axis=1)
+            tpeak_jall_idx = ak.argmin(abs(jjjall_4vec.mass - 173),keepdims=True,axis=1)
+            tpeak_jcnt_idx = ak.argmin(abs(jjjcnt_4vec.mass - 173),keepdims=True,axis=1)
             mjjjall_nearest_t = ak.fill_none(ak.flatten(jjjall_4vec[tpeak_jall_idx].mass),0)
             mjjjcnt_nearest_t = ak.fill_none(ak.flatten(jjjcnt_4vec[tpeak_jcnt_idx].mass),0)
 
@@ -519,7 +525,8 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             # Mjj max from any jets
             jjCentFwd_pairs = ak.combinations( goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
-            mjj_max_any  = ak.fill_none(ak.max((jjCentFwd_pairs.j0 + jjCentFwd_pairs.j1).mass,axis=-1),0)
+            mjj_max_any     = ak.fill_none(ak.max((jjCentFwd_pairs.j0 + jjCentFwd_pairs.j1).mass,axis=-1),0)
+            absdeta_max_any = ak.fill_none(ak.max(abs(jjCentFwd_pairs.j0.eta - jjCentFwd_pairs.j1.eta),axis=-1),0)
 
             # Mjj max from cent jets
             jjCent_pairs = ak.combinations(goodJets_ptordered_padded, 2, fields=["j0", "j1"] )
@@ -528,47 +535,33 @@ class AnalysisProcessor(processor.ProcessorABC):
             # Mjj max from forward jets
             jjFwd_pairs = ak.combinations(goodJets_forward_ptordered_padded, 2, fields=["j0", "j1"] )
             mjj_max_fwd = ak.fill_none(ak.max((jjFwd_pairs.j0 + jjFwd_pairs.j1).mass,axis=-1),0)
+            absdeta_max_fwd = ak.fill_none(ak.max(abs(jjFwd_pairs.j0.eta - jjFwd_pairs.j1.eta),axis=-1),0)
 
-            ### TMP!!! These are not in R3, so just use particleNet_QCD for all for now so we don't crash ###
-            fj0_pNetH4qvsQCD = fj0.particleNet_QCD
-            fj0_pNetHbbvsQCD = fj0.particleNet_QCD
-            fj0_pNetHccvsQCD = fj0.particleNet_QCD
-            fj0_pNetQCD      = fj0.particleNet_QCD
-            fj0_pNetTvsQCD   = fj0.particleNet_QCD
-            fj0_pNetWvsQCD   = fj0.particleNet_QCD
-            fj0_pNetZvsQCD   = fj0.particleNet_QCD
-            fj0_mparticlenet = fj0.particleNet_QCD
-
-            fj1_pNetH4qvsQCD = fj1.particleNet_QCD
-            fj1_pNetHbbvsQCD = fj1.particleNet_QCD
-            fj1_pNetHccvsQCD = fj1.particleNet_QCD
-            fj1_pNetQCD      = fj1.particleNet_QCD
-            fj1_pNetTvsQCD   = fj1.particleNet_QCD
-            fj1_pNetWvsQCD   = fj1.particleNet_QCD
-            fj1_pNetZvsQCD   = fj1.particleNet_QCD
-            fj1_mparticlenet = fj1.particleNet_QCD
-
-            # Only for R2
-            #fj0_pNetH4qvsQCD = fj0.particleNet_H4qvsQCD
-            #fj0_pNetHbbvsQCD = fj0.particleNet_HbbvsQCD
-            #fj0_pNetHccvsQCD = fj0.particleNet_HccvsQCD
-            #fj0_pNetQCD      = fj0.particleNet_QCD
-            #fj0_pNetTvsQCD   = fj0.particleNet_TvsQCD
-            #fj0_pNetWvsQCD   = fj0.particleNet_WvsQCD
-            #fj0_pNetZvsQCD   = fj0.particleNet_ZvsQCD
-            #fj0_mparticlenet = fj0.particleNet_mass
-            #fj1_pNetH4qvsQCD = fj1.particleNet_H4qvsQCD
-            #fj1_pNetHbbvsQCD = fj1.particleNet_HbbvsQCD
-            #fj1_pNetHccvsQCD = fj1.particleNet_HccvsQCD
-            #fj1_pNetQCD      = fj1.particleNet_QCD
-            #fj1_pNetTvsQCD   = fj1.particleNet_TvsQCD
-            #fj1_pNetWvsQCD   = fj1.particleNet_WvsQCD
-            #fj1_pNetZvsQCD   = fj1.particleNet_ZvsQCD
-            #fj1_mparticlenet = fj1.particleNet_mass
             ###
+            #if year == "2024":
+            if 1:
+                # Only for R3
+                fj0_pNetH4qvsQCD = fj0.particleNetWithMass_H4qvsQCD
+                fj0_pNetHbbvsQCD = fj0.particleNetWithMass_HbbvsQCD
+                fj0_pNetHccvsQCD = fj0.particleNetWithMass_HccvsQCD
+                fj0_pNetQCD      = fj0.particleNetWithMass_QCD
+                fj0_pNetTvsQCD   = fj0.particleNetWithMass_TvsQCD
+                fj0_pNetWvsQCD   = fj0.particleNetWithMass_WvsQCD
+                fj0_pNetZvsQCD   = fj0.particleNetWithMass_ZvsQCD
+                fj0_mparticlenet = fj0.particleNetLegacy_mass
+            else:
+                # Only for R2
+                fj0_pNetH4qvsQCD = fj0.particleNet_H4qvsQCD
+                fj0_pNetHbbvsQCD = fj0.particleNet_HbbvsQCD
+                fj0_pNetHccvsQCD = fj0.particleNet_HccvsQCD
+                fj0_pNetQCD      = fj0.particleNet_QCD
+                fj0_pNetTvsQCD   = fj0.particleNet_TvsQCD
+                fj0_pNetWvsQCD   = fj0.particleNet_WvsQCD
+                fj0_pNetZvsQCD   = fj0.particleNet_ZvsQCD
+                fj0_mparticlenet = fj0.particleNet_mass
 
 
-            ### Put the variables we'll plot into a dictionary for easy access later ###
+            # Put the variables we'll plot into a dictionary for easy access later
             dense_variables_dict = {
                 "met" : met.pt,
                 "metphi" : met.phi,
@@ -590,6 +583,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "l2_eta" : l2_eta,
                 "mass_l0l1" : mass_l0l1,
                 "dr_l0l1" : dr_l0l1,
+                "l0_iso"     : l0.pfRelIso03_all,
+                "l0_miniiso" : l0.miniPFRelIso_all,
+                "l1_iso"     : l1.pfRelIso03_all,
+                "l1_miniiso" : l1.miniPFRelIso_all,
+                "l2_iso"     : l2.pfRelIso03_all,
+                "l2_miniiso" : l2.miniPFRelIso_all,
 
                 "j0central_pt" : j0central_pt,
                 "j0central_eta" : j0central_eta,
@@ -623,11 +622,11 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "fj0_eta" : fj0.eta,
                 "fj0_phi" : fj0.phi,
 
-                "fj1_pt" : fj1.pt,
-                "fj1_mass" : fj1.mass,
-                "fj1_msoftdrop" : fj1.msoftdrop,
-                "fj1_eta" : fj1.eta,
-                "fj1_phi" : fj1.phi,
+                #"fj1_pt" : fj1.pt,
+                #"fj1_mass" : fj1.mass,
+                #"fj1_msoftdrop" : fj1.msoftdrop,
+                #"fj1_eta" : fj1.eta,
+                #"fj1_phi" : fj1.phi,
 
                 "j0_pt" : j0.pt,
                 "j0_eta" : j0.eta,
@@ -656,14 +655,14 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "fj0_pNetZvsQCD"   : fj0_pNetZvsQCD,
                 "fj0_mparticlenet" : fj0_mparticlenet,
 
-                "fj1_pNetH4qvsQCD" : fj1_pNetH4qvsQCD,
-                "fj1_pNetHbbvsQCD" : fj1_pNetHbbvsQCD,
-                "fj1_pNetHccvsQCD" : fj1_pNetHccvsQCD,
-                "fj1_pNetQCD"      : fj1_pNetQCD,
-                "fj1_pNetTvsQCD"   : fj1_pNetTvsQCD,
-                "fj1_pNetWvsQCD"   : fj1_pNetWvsQCD,
-                "fj1_pNetZvsQCD"   : fj1_pNetZvsQCD,
-                "fj1_mparticlenet" : fj1_mparticlenet,
+                #"fj1_pNetH4qvsQCD" : fj1_pNetH4qvsQCD,
+                #"fj1_pNetHbbvsQCD" : fj1_pNetHbbvsQCD,
+                #"fj1_pNetHccvsQCD" : fj1_pNetHccvsQCD,
+                #"fj1_pNetQCD"      : fj1_pNetQCD,
+                #"fj1_pNetTvsQCD"   : fj1_pNetTvsQCD,
+                #"fj1_pNetWvsQCD"   : fj1_pNetWvsQCD,
+                #"fj1_pNetZvsQCD"   : fj1_pNetZvsQCD,
+                #"fj1_mparticlenet" : fj1_mparticlenet,
 
                 "jj_pairs_atmindr_mjj" : jj_pairs_atmindr_mjj,
 
@@ -680,6 +679,9 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "mjj_max_cent" : mjj_max_cent,
                 "mjj_max_fwd" : mjj_max_fwd,
 
+                "absdeta_max_fwd" : absdeta_max_fwd,
+                "absdeta_max_any" : absdeta_max_any,
+
                 "mjjjall_nearest_t": mjjjall_nearest_t,
                 "mjjjcnt_nearest_t": mjjjcnt_nearest_t,
 
@@ -693,6 +695,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "mljjjjany" : mljjjjany,
                 "mljjjjcnt" : mljjjjcnt,
 
+                #"ghiggs0_pt" : ghiggs0.pt,
+                #"gvectorboson0_pt" : gvectorboson0.pt,
+
+                "n_ll_sfos": n_ll_sfos,
+                "abs_ch_sum_3l": abs_ch_sum_3l,
+
             }
 
 
@@ -700,119 +708,84 @@ class AnalysisProcessor(processor.ProcessorABC):
 
             selections = PackedSelection(dtype='uint64')
 
-            # Form some other useful masks for SRs
+            # Form some useful masks for SRs
 
-            mask_exactly1lep_exactly2fj = (nleps==1) & (nfatjets==2)
-            mask_exactly1lep_exactly1fj = (nleps==1) & (nfatjets==1)
-            mask_presel = mask_exactly1lep_exactly1fj & (scalarptsum_lepmet > 775)
+            is_os = l0.pdgId*l1.pdgId<0
+            is_sf = abs(l0.pdgId) == abs(l1.pdgId)
 
-            mask_preselHFJ = mask_presel & (fj0_mparticlenet >  100.) & (fj0_mparticlenet <= 150.)
-            mask_preselVFJ = mask_presel & (fj0_mparticlenet <= 100.) & (fj0_mparticlenet > 65)
-            mask_HFJ = (fj0_mparticlenet >  100.) & (fj0_mparticlenet <= 150.)
-            mask_VFJ = (fj0_mparticlenet <= 100.) & (fj0_mparticlenet > 65)
+            is_2l = (nleps==2) & (l0.pt>25) & (l1.pt>15)
+            is_3l = (nleps==3) & (l0.pt>25) & (l1.pt>15) & (l2.pt>10)
 
-            mask_preselHFJTag = mask_preselHFJ & (fj0_pNetHbbvsQCD > 0.98) & (fj0_pNetTvsQCD < 0.5) & (fj0_pNetWvsQCD < 0.5)
-            mask_preselVFJTag = mask_preselVFJ & (fj0_pNetWvsQCD > 0.95) & (fj0_pNetTvsQCD < 0.5)
-            mask_HFJTagHbb = (fj0_pNetHbbvsQCD > 0.98)
-            mask_HFJtag = (fj0_pNetHbbvsQCD > 0.98) & (fj0_pNetTvsQCD < 0.5) & (fj0_pNetWvsQCD < 0.5)
-            mask_VFJtag = (fj0_pNetWvsQCD > 0.95) & (fj0_pNetTvsQCD < 0.5)
+            is_VFJ       = (fj0_mparticlenet <= 100.) & (fj0_mparticlenet > 65)
+            is_HFJ       = (fj0_mparticlenet >  110.) & (fj0_mparticlenet <= 150.)
+            is_HFJTagHbb = (fj0_pNetHbbvsQCD > 0.98)
 
-            ### Pre selections ###
-            selections.add("all_events", (veto_map_mask | (~veto_map_mask))) # All events.. this logic is a bit roundabout to just get an array of True
+            is_onZ = abs(mass_l0l1 - 91.1876) < 20
 
-            ### 1lep + 1FJ ###
-            selections.add("exactly1lep_exactly1fj" , mask_exactly1lep_exactly1fj)
-            selections.add("presel", mask_presel)
-            # HFJ selections
-            selections.add("preselHFJ", mask_preselHFJ)
-            selections.add("preselHFJTag",mask_preselHFJTag)
-            selections.add("preselHFJTag_mjj115", mask_preselHFJTag & (mass_j0centj1cent < 115))
-            # VFJ selections
-            selections.add("preselVFJ", mask_preselVFJ)
-            selections.add("preselVFJTag",                                  mask_preselVFJTag)
-            selections.add("preselVFJTag_mjjcent75to150",                   mask_preselVFJTag & (mass_j0centj1cent>75) & (mass_j0centj1cent<150))
-            selections.add("preselVFJTag_mjjcent75to150_mbb75to150",        mask_preselVFJTag & (mass_j0centj1cent>75) & (mass_j0centj1cent<150) & (mass_b0b1>75) & (mass_b0b1<150))
-            selections.add("preselVFJTag_mjjcent75to150_mbb75to150_mvqq75p",mask_preselVFJTag & (mass_j0centj1cent>75) & (mass_j0centj1cent<150) & (mass_b0b1>75) & (mass_b0b1<150) & (jj_pairs_atmindr_mjj > 75))
 
-            ### 1lep + 2FJ ###
-            selections.add("exactly1lep_exactly2fj" ,                          mask_exactly1lep_exactly2fj)
-            selections.add("exactly1lep_exactly2fj_lepmet600" ,                mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600))
-            selections.add("exactly1lep_exactly2fj_lepmet600_VFJ" ,            mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_VFJ)
-            selections.add("exactly1lep_exactly2fj_lepmet600_VFJtag" ,         mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_VFJ & mask_VFJtag)
-            selections.add("exactly1lep_exactly2fj_lepmet600_VFJtag_njcent0" , mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_VFJ & mask_VFJtag & (njets==0))
-            selections.add("exactly1lep_exactly2fj_lepmet600_HFJ" ,            mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_HFJ)
-            selections.add("exactly1lep_exactly2fj_lepmet600_HFJtagZ" ,        mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_HFJ & (fj0_pNetZvsQCD>0.5))
-            selections.add("exactly1lep_exactly2fj_lepmet600_HFJtagZ_njcent0" ,mask_exactly1lep_exactly2fj & (scalarptsum_lepmet>600) & mask_HFJ & (fj0_pNetZvsQCD>0.5) & (njets==0))
-
-            selections.add("exactly1lep_l40_noloosel" , (nleps==1)    & (l0.pt>40))
-            ## Test
-            selections.add("exactly2fj_l40_noloosel"  , (nfatjets==2) & (l0.pt>40))
-            selections.add("exactly1lep_l40_noloosel" , (nleps==1)    & (l0.pt>40))
-            selections.add("exactly1lep_exactly2fj_l40_noloosel"  , (nleps==1) & (nfatjets==2) & (l0.pt>40))
-            ##
+            ### Inclusive selections ###
+            #filter_mask = es_ec.get_filter_flag_mask_vvh(events,year,is2022,is2023) # Get the filter flag mask
+            filter_mask = pass_through
+            lumi_mask = pass_through
+            pass_trg = pass_through
+            quality = filter_mask & lumi_mask & pass_trg # This is what we'll actually apply to the SRs
+            # Cut flow for quality mask
+            selections.add("all_events",     pass_through) # Just a pass through
+            selections.add("just2lep",       (nleps==2))
+            selections.add("just3lep",       (nleps==3))
+            selections.add("filter",         filter_mask)
+            selections.add("filter_grl",     filter_mask & lumi_mask)
+            selections.add("filter_grl_trg", filter_mask & lumi_mask & pass_trg)
 
             ### 2lOS + 1FJ ###
-            os_mask = l0.pdgId*l1.pdgId<0
-            ss_mask = l0.pdgId*l1.pdgId>0
-            mask_exactly2lepOS = (nleps==2) & os_mask
-            mask_exactly2lepSS = (nleps==2) & ss_mask
-            mask_exactly2lepSS_exactly1fj = mask_exactly2lepSS & (nfatjets==1)
-            mask_exactly2lepOS_exactly1fj = mask_exactly2lepOS & (nfatjets==1)
-            mask_exactly2lepOS_exactly2fj = mask_exactly2lepOS & (nfatjets==2)
-            selections.add("exactly2lepOS"                                    , mask_exactly2lepOS)
-            selections.add("exactly2lepOS_exactly1fj"                         , mask_exactly2lepOS_exactly1fj)
-            selections.add("exactly2lepOS_exactly1fj_HFJ"                     , mask_exactly2lepOS_exactly1fj & mask_HFJ)
-            selections.add("exactly2lepOS_exactly1fj_HFJtag"                  , mask_exactly2lepOS_exactly1fj & mask_HFJ & mask_HFJTagHbb)
-            selections.add("exactly2lepOS_exactly1fj_HFJtag_lepmetjetf800"    , mask_exactly2lepOS_exactly1fj & mask_HFJ & mask_HFJTagHbb & (scalarptsum_lepmetfwdjets>800))
-            selections.add("exactly2lepOS_exactly1fj_VFJ"                     , mask_exactly2lepOS_exactly1fj & mask_VFJ)
-            selections.add("exactly2lepOS_exactly1fj_VFJ_met100"              , mask_exactly2lepOS_exactly1fj & mask_VFJ & (met.pt>100))
-            selections.add("exactly2lepOS_exactly1fj_VFJ_met100_lepmetjetf700", mask_exactly2lepOS_exactly1fj & mask_VFJ & (met.pt>100) & (scalarptsum_lepmetfwdjets>700))
+            selections.add("2l",                                quality & is_2l)
+            selections.add("2lOS",                              quality & is_2l & is_os)
+            selections.add("2lOSSF",                            quality & is_2l & is_os & is_sf)
+            selections.add("2lOSSF_1fj",                        quality & is_2l & is_os & is_sf & (nfatjets>=1))
+            selections.add("2lOSSF_1fjx",                       quality & is_2l & is_os & is_sf & (nfatjets==1))
+            selections.add("2lOSSF_1fjx_onZ",                   quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ)
+            selections.add("2lOSSF_1fjx_onZ_HFJ",               quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ)
+            selections.add("2lOSSF_1fjx_onZ_HFJtag",            quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb)
+            selections.add("2lOSSF_1fjx_onZ_HFJtag_nj2",        quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb & (njets_tot>=2))
+            selections.add("2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600", quality & is_2l & is_os & is_sf & (nfatjets==1) & is_onZ & is_HFJ & is_HFJTagHbb & (njets_tot>=2) & (mjj_max_any>600))
+
+            ### 3l ###
+            selections.add("3l",                  quality & is_3l)
+            selections.add("3l_2j_mjj600",        quality & is_3l & (njets_tot>=2) & (mjj_max_any>600))
+            selections.add("3l_2j_mjj600_ht350",  quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (scalarptsum_lepmetalljets>350))
+            selections.add("3l_2j_mjj600_noSFOS", quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (n_ll_sfos==0))
+            selections.add("3l_2j_mjj600_ch3",    quality & is_3l & (njets_tot>=2) & (mjj_max_any>600) & (abs_ch_sum_3l==3))
 
 
-
+            # Keep track of the ones we want to actually fill
             cat_dict = {
                 "lep_chan_lst" : [
 
-                    "all_events",
-                    #"exactly1lep",
+                    #"all_events",
+                    #"filter",
+                    #"filter_grl",
+                    #"filter_grl_trg",
+                    "just2lep",
+                    #"just3lep",
 
-                    ### 1lep 1FJ ###
-                    "exactly1lep_exactly1fj",
-                    "presel",
-                    "preselHFJ",
-                    "preselHFJTag",
-                    "preselHFJTag_mjj115",
-                    "preselVFJ",
-                    "preselVFJTag",
-                    "preselVFJTag_mjjcent75to150",
-                    "preselVFJTag_mjjcent75to150_mbb75to150",
-                    "preselVFJTag_mjjcent75to150_mbb75to150_mvqq75p",
+                    #### 2l OS SF 1FJ ###
+                    #"2l",
+                    #"2lOS",
+                    #"2lOSSF",
+                    #"2lOSSF_1fj",
+                    #"2lOSSF_1fjx",
+                    #"2lOSSF_1fjx_onZ",
+                    #"2lOSSF_1fjx_onZ_HFJ",
+                    #"2lOSSF_1fjx_onZ_HFJtag",
+                    #"2lOSSF_1fjx_onZ_HFJtag_nj2",
+                    #"2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
 
-                    ### 1lep+2FJ ###
-                    "exactly1lep_exactly2fj",
-                    "exactly1lep_exactly2fj_lepmet600",
-                    "exactly1lep_exactly2fj_lepmet600_VFJ",
-                    "exactly1lep_exactly2fj_lepmet600_VFJtag",
-                    "exactly1lep_exactly2fj_lepmet600_VFJtag_njcent0",
-                    "exactly1lep_exactly2fj_lepmet600_HFJ",
-                    "exactly1lep_exactly2fj_lepmet600_HFJtagZ",
-                    "exactly1lep_exactly2fj_lepmet600_HFJtagZ_njcent0",
-                    ## Test
-                    "exactly2fj_l40_noloosel",
-                    "exactly1lep_l40_noloosel",
-                    "exactly1lep_exactly2fj_l40_noloosel",
-                    ##
-
-                    ### 2lOS 1FJ ###
-                    "exactly2lepOS",
-                    "exactly2lepOS_exactly1fj",
-                    "exactly2lepOS_exactly1fj_HFJ",
-                    "exactly2lepOS_exactly1fj_HFJtag",
-                    "exactly2lepOS_exactly1fj_HFJtag_lepmetjetf800",
-                    #"exactly2lepOS_exactly1fj_VFJ",
-                    #"exactly2lepOS_exactly1fj_VFJ_met100",
-                    #"exactly2lepOS_exactly1fj_VFJ_met100_lepmetjetf700",
-
+                    #### 3l ###
+                    #"3l",
+                    #"3l_2j_mjj600",
+                    #"3l_2j_mjj600_ht350",
+                    #"3l_2j_mjj600_noSFOS",
+                    #"3l_2j_mjj600_ch3",
                 ]
             }
 
@@ -895,6 +868,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                             "category"      : sr_cat,
                             "systematic"    : wgt_fluct,
                         }
+
                         self.accumulator[dense_axis_name].fill(**axes_fill_info_dict)
 
         return self.accumulator

--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -3,7 +3,6 @@
 import coffea
 import numpy as np
 import awkward as ak
-import copy
 np.seterr(divide='ignore', invalid='ignore', over='ignore')
 from coffea import processor
 import hist

--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -181,6 +181,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                 hist.axis.StrCategory([], growth=True, name="process", label="process"),
                 hist.axis.StrCategory([], growth=True, name="category", label="category"),
                 hist.axis.StrCategory([], growth=True, name="systematic", label="systematic"),
+                hist.axis.StrCategory([], growth=True, name="year", label="year"),
                 self._dense_axes_dict[dense_axis_name],
                 storage="weight", # Keeps track of sumw2
                 name="Counts",
@@ -220,7 +221,7 @@ class AnalysisProcessor(processor.ProcessorABC):
 
         isData       = self._samples[json_name]["isData"]
         #histAxisName = events.namewithyear
-        histAxisName = events.name
+        histAxisName = events.shortname
         year         = events.year
         xsec         = events.xsec
 
@@ -256,6 +257,9 @@ class AnalysisProcessor(processor.ProcessorABC):
         # An array of lenght events that is just 1 for each event
         # Probably there's a better way to do this, but we use this method elsewhere so I guess why not..
         events.nom = ak.ones_like(met.pt)
+        #events.weight = events.nom
+        #events.weight = 1000* events.xsec * events.lumi * events.genWeight / events.sumw
+        #events.weight = events.baseweight
 
         # A mask that is all True by construction
         # Probably there's a better way to do this...
@@ -288,14 +292,17 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Note: add() will generally modify up/down weights, so if these are needed for any reason after this point, we should instead pass copies to add()
         # Note: Here we will to the weights object the SFs that do not depend on any of the forthcoming loops
         weights_obj_base = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
-        if not isData:
-            #genw_raw = events.weight
-            #genw = events.weight
-            genw_raw = 1
-            genw = 1
+        #if not isData:
+        if hasattr(events, "baseweight"):
+            events.weight = events.baseweight
+            genw_raw = events.weight
+            genw = events.weight
+            #genw_raw = 1
+            #genw = 1
 
             # Normalize to the weight from RDF
-            weights_obj_base.add("norm",events.weight * genw/genw_raw)
+            #weights_obj_base.add("norm",events.weight * genw/genw_raw)
+            weights_obj_base.add("norm",events.weight)
 
 
         ######### The rest of the processor is inside this loop over systs that affect object kinematics  ###########
@@ -516,12 +523,12 @@ class AnalysisProcessor(processor.ProcessorABC):
             mass_bmbscore0bmbscore1 = ak.fill_none((bmbscore0+bmbscore1).mass,0)
 
             # Variables related to leading b jet score of central jets
-            centraljets_bscoreordered = goodJets_ptordered_padded[ak.argsort(goodJets_ptordered_padded.btagDeepFlavB,axis=-1,ascending=False)]
-            jbscore0 = centraljets_bscoreordered[:,0]
-            jbscore1 = centraljets_bscoreordered[:,1]
-            mass_jbscore0jbscore1 = ak.fill_none((jbscore0+jbscore1).mass,0)
-            jbscore0_bscore = ak.fill_none(jbscore0.btagDeepFlavB,0)
-            jbscore1_bscore = ak.fill_none(jbscore1.btagDeepFlavB,0)
+            #centraljets_bscoreordered = goodJets_ptordered_padded[ak.argsort(goodJets_ptordered_padded.btagDeepFlavB,axis=-1,ascending=False)]
+            #jbscore0 = centraljets_bscoreordered[:,0]
+            #jbscore1 = centraljets_bscoreordered[:,1]
+            #mass_jbscore0jbscore1 = ak.fill_none((jbscore0+jbscore1).mass,0)
+            #jbscore0_bscore = ak.fill_none(jbscore0.btagDeepFlavB,0)
+            #jbscore1_bscore = ak.fill_none(jbscore1.btagDeepFlavB,0)
 
             # Mjj max from any jets
             jjCentFwd_pairs = ak.combinations( goodJetsCentFwd_ptordered_padded, 2, fields=["j0", "j1"] )
@@ -671,9 +678,9 @@ class AnalysisProcessor(processor.ProcessorABC):
                 "mass_bbscore0bbscore1" : mass_bbscore0bbscore1,
                 "mass_bmbscore0bmbscore1" : mass_bmbscore0bmbscore1,
 
-                "jbscore0_bscore" : jbscore0_bscore,
-                "jbscore1_bscore" : jbscore1_bscore,
-                "mass_jbscore0jbscore1" : mass_jbscore0jbscore1,
+                #"jbscore0_bscore" : jbscore0_bscore,
+                #"jbscore1_bscore" : jbscore1_bscore,
+                #"mass_jbscore0jbscore1" : mass_jbscore0jbscore1,
 
                 "mjj_max_any" : mjj_max_any,
                 "mjj_max_cent" : mjj_max_cent,
@@ -729,6 +736,7 @@ class AnalysisProcessor(processor.ProcessorABC):
             lumi_mask = pass_through
             pass_trg = pass_through
             quality = filter_mask & lumi_mask & pass_trg # This is what we'll actually apply to the SRs
+            quality = pass_through
             # Cut flow for quality mask
             selections.add("all_events",     pass_through) # Just a pass through
             selections.add("just2lep",       (nleps==2))
@@ -761,31 +769,31 @@ class AnalysisProcessor(processor.ProcessorABC):
             cat_dict = {
                 "lep_chan_lst" : [
 
-                    #"all_events",
-                    #"filter",
-                    #"filter_grl",
-                    #"filter_grl_trg",
+                    "all_events",
+                    "filter",
+                    "filter_grl",
+                    "filter_grl_trg",
                     "just2lep",
-                    #"just3lep",
+                    "just3lep",
 
-                    #### 2l OS SF 1FJ ###
-                    #"2l",
-                    #"2lOS",
-                    #"2lOSSF",
-                    #"2lOSSF_1fj",
-                    #"2lOSSF_1fjx",
-                    #"2lOSSF_1fjx_onZ",
-                    #"2lOSSF_1fjx_onZ_HFJ",
-                    #"2lOSSF_1fjx_onZ_HFJtag",
-                    #"2lOSSF_1fjx_onZ_HFJtag_nj2",
-                    #"2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
+                    ### 2l OS SF 1FJ ###
+                    "2l",
+                    "2lOS",
+                    "2lOSSF",
+                    "2lOSSF_1fj",
+                    "2lOSSF_1fjx",
+                    "2lOSSF_1fjx_onZ",
+                    "2lOSSF_1fjx_onZ_HFJ",
+                    "2lOSSF_1fjx_onZ_HFJtag",
+                    "2lOSSF_1fjx_onZ_HFJtag_nj2",
+                    "2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
 
-                    #### 3l ###
-                    #"3l",
-                    #"3l_2j_mjj600",
-                    #"3l_2j_mjj600_ht350",
-                    #"3l_2j_mjj600_noSFOS",
-                    #"3l_2j_mjj600_ch3",
+                    ### 3l ###
+                    "3l",
+                    "3l_2j_mjj600",
+                    "3l_2j_mjj600_ht350",
+                    "3l_2j_mjj600_noSFOS",
+                    "3l_2j_mjj600_ch3",
                 ]
             }
 
@@ -800,7 +808,8 @@ class AnalysisProcessor(processor.ProcessorABC):
             # For now the syst do not depend on the category, so we can figure this out outside of the filling loop
             wgt_var_lst = ["nominal"]
             if self._do_systematics:
-                if not isData:
+                #if not isData:
+                if not hasattr(events, "baseweight"):
                     if (obj_corr_syst_var != "nominal"):
                         # In this case, we are dealing with systs that change the kinematics of the objs (e.g. JES)
                         # So we don't want to loop over up/down weight variations here
@@ -867,6 +876,7 @@ class AnalysisProcessor(processor.ProcessorABC):
                             "process"       : histAxisName[all_cuts_mask],
                             "category"      : sr_cat,
                             "systematic"    : wgt_fluct,
+                            "year"          : events.year[all_cuts_mask],
                         }
 
                         self.accumulator[dense_axis_name].fill(**axes_fill_info_dict)

--- a/analysis/vbs_vvh/analysis_processor_semilep.py
+++ b/analysis/vbs_vvh/analysis_processor_semilep.py
@@ -26,7 +26,7 @@ get_ec_param = GetParam(ewkcoffea_path("params/params.json"))
 
 class AnalysisProcessor(processor.ProcessorABC):
 
-    def __init__(self, samples, wc_names_lst=[], hist_lst=None, do_systematics=False, skip_obj_systematics=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, siphon_bdt_data=False):
+    def __init__(self, samples, wc_names_lst=[], hist_lst=None, do_systematics=False, skip_obj_systematics=False, skip_signal_regions=False, skip_control_regions=False, muonSyst='nominal', dtype=np.float32, siphon_bdt_data=False, rwgt_to_sm=False):
 
         self._samples = samples
         self._wc_names_lst = wc_names_lst
@@ -212,7 +212,8 @@ class AnalysisProcessor(processor.ProcessorABC):
         json_name = events.metadata["dataset"]
 
         isData       = self._samples[json_name]["isData"]
-        histAxisName = events.namewithyear
+        #histAxisName = events.namewithyear
+        histAxisName = events.name
         year         = events.year
         xsec         = events.xsec
 
@@ -236,12 +237,12 @@ class AnalysisProcessor(processor.ProcessorABC):
                 raise Exception(f"ERROR: Unexpected dataset name for data file: {dataset}")
 
         # Initialize objects
-        ele     = events.Electron
-        mu      = events.Muon
-        jets    = events.Jet
+        ele     = events.electron
+        mu      = events.muon
+        jets    = events.jet
         #met     = events.MET
         met     = events.PuppiMET
-        fatjets = events.FatJet
+        fatjets = events.fatjet
         #fatjets = events.CorrFatJet
         #higgs   = events.Higgs
 
@@ -276,11 +277,13 @@ class AnalysisProcessor(processor.ProcessorABC):
         # Note: Here we will to the weights object the SFs that do not depend on any of the forthcoming loops
         weights_obj_base = coffea.analysis_tools.Weights(len(events),storeIndividual=True)
         if not isData:
-            if ak.any(events["LHEReweightingWeight"]):
-                genw = events["LHEReweightingWeight"][:,60]
-            else:
-                genw = events["genWeight"]
-            genw_raw = events["genWeight"]
+            #if ak.any(events["LHEReweightingWeight"]):
+            #    genw = events["LHEReweightingWeight"][:,60]
+            #else:
+            #    genw = events["genWeight"]
+            #genw_raw = events["genWeight"]
+            genw_raw = 1
+            genw = 1
 
             # Normalize to the weight from RDF
             weights_obj_base.add("norm",events.weight * genw/genw_raw)

--- a/analysis/vbs_vvh/check_vvh_hists.py
+++ b/analysis/vbs_vvh/check_vvh_hists.py
@@ -28,15 +28,16 @@ GRP_DICT_FULL_R3 = {
     ],
 }
 
+
 GRP_DICT_FULL_R2 = {
     "Data" : [
         "data",
     ],
     "Signal" : [
-        "VBSWWH_OS_VBSCuts_13TeV",
-        "VBSWWH_SS_VBSCuts_13TeV",
-        "VBSWZH_VBSCuts_13TeV",
-        "VBSZZH_VBSCuts_13TeV",
+        "VBSWWH_SS_c2v1p0_c3_1p0",
+        "VBSWWH_OS_c2v1p0_c3_1p0",
+        "VBSWZH_c2v1p0_c3_1p0",
+        "VBSZZH_c2v1p0_c3_1p0",
     ],
     "QCD" : [
         "QCD_HT50to100_TuneCP5_PSWeights_13TeV",
@@ -50,41 +51,36 @@ GRP_DICT_FULL_R2 = {
         "QCD_HT2000toInf_TuneCP5_PSWeights_13TeV",
     ],
     "ttbar" : [
-        "TTToHadronic_TuneCP5_13TeV",
-        "TTToSemiLeptonic_TuneCP5_13TeV",
         "TTTo2L2Nu_TuneCP5_13TeV",
+        "TTToSemiLeptonic_TuneCP5_13TeV",
+        "TTToHadronic_TuneCP5_13TeV",
     ],
     "single-t" : [
+        "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV",
+        "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV",
         "ST_tW_antitop_5f_inclusiveDecays_TuneCP5_13TeV",
         "ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV",
         "ST_s-channel_4f_leptonDecays_TuneCP5_13TeV",
-        "ST_t-channel_top_4f_InclusiveDecays_TuneCP5_13TeV",
-        "ST_t-channel_antitop_4f_InclusiveDecays_TuneCP5_13TeV",
     ],
     "ttX" : [
-        #"TTbb_4f_TTToSemiLeptonic", # Not sure
-        #"TTbb_4f_TTToHadronic", # Not sure
-        #"TTbb_4f_TTTo2L2Nu", # Not sure
-        "ttZJets_TuneCP5_13TeV",
-        "TTZToLLNuNu_M-10_TuneCP5_13TeV",
         "TTWJetsToLNu_TuneCP5_13TeV",
         "TTWJetsToQQ_TuneCP5_13TeV",
-        "ttWJets_TuneCP5_13TeV",
-        "ttHTobb_M125_TuneCP5_13TeV",
+        "TTWW_TuneCP5_13TeV",
+        "TTWZ_TuneCP5_13TeV",
+        "TTZToLLNuNu_M-10_TuneCP5_13TeV",
+        "TTbb_4f_TTTo2L2Nu",
+        "TTbb_4f_TTToSemiLeptonic",
+        "TTbb_4f_TTToHadronic",
         "ttHToNonbb_M125_TuneCP5_13TeV",
+        "ttHTobb_M125_TuneCP5_13TeV",
+        "ttWJets_TuneCP5_13TeV",
+        "ttZJets_TuneCP5_13TeV",
     ],
     "rare-top" : [
-        "TTWZ_TuneCP5_13TeV",
-        "TTWW_TuneCP5_13TeV",
-        "tZq_ll_4f_ckm_NLO_TuneCP5_13TeV",
         "TWZToLL_tlept_Wlept_5f_DR_TuneCP5_13TeV",
+        "tZq_ll_4f_ckm_NLO_TuneCP5_13TeV",
     ],
     "Vjets" : [
-        "WJetsToQQ_HT-200to400_TuneCP5_13TeV",
-        "WJetsToQQ_HT-400to600_TuneCP5_13TeV",
-        "WJetsToQQ_HT-600to800_TuneCP5_13TeV",
-        "WJetsToQQ_HT-800toInf_TuneCP5_13TeV",
-        "WJetsToLNu_TuneCP5_13TeV",
         "WJetsToLNu_HT-70To100_TuneCP5_13TeV",
         "WJetsToLNu_HT-100To200_TuneCP5_13TeV",
         "WJetsToLNu_HT-200To400_TuneCP5_13TeV",
@@ -93,75 +89,84 @@ GRP_DICT_FULL_R2 = {
         "WJetsToLNu_HT-800To1200_TuneCP5_13TeV",
         "WJetsToLNu_HT-1200To2500_TuneCP5_13TeV",
         "WJetsToLNu_HT-2500ToInf_TuneCP5_13TeV",
+        "WJetsToLNu_TuneCP5_13TeV",
+        "WJetsToQQ_HT-200to400_TuneCP5_13TeV",
+        "WJetsToQQ_HT-400to600_TuneCP5_13TeV",
+        "WJetsToQQ_HT-600to800_TuneCP5_13TeV",
+        "WJetsToQQ_HT-800toInf_TuneCP5_13TeV",
         "ZJetsToQQ_HT-200to400_TuneCP5_13TeV",
         "ZJetsToQQ_HT-400to600_TuneCP5_13TeV",
         "ZJetsToQQ_HT-600to800_TuneCP5_13TeV",
         "ZJetsToQQ_HT-800toInf_TuneCP5_13TeV",
+        "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV",
+        "WminusH_HToBB_WToQQ_M-125_TuneCP5_13TeV",
+        "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV",
+        "WplusH_HToBB_WToQQ_M-125_TuneCP5_13TeV",
+    ],
+    "DY" : [
         "DYJetsToLL_M-10to50_TuneCP5_13TeV",
         "DYJetsToLL_M-50_TuneCP5_13TeV",
     ],
     "ewkV" : [
-        "EWKZ2Jets_ZToLL_M-50_TuneCP5_withDipoleRecoil_13TeV",
-        "EWKZ2Jets_ZToQQ_dipoleRecoilOn_TuneCP5_13TeV",
-        "EWKZ2Jets_ZToNuNu_M-50_TuneCP5_withDipoleRecoil_13TeV",
         "EWKWMinus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV",
+        "EWKWPlus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV",
         "EWKWminus2Jets_WToQQ_dipoleRecoilOn_TuneCP5_13TeV",
         "EWKWplus2Jets_WToQQ_dipoleRecoilOn_TuneCP5_13TeV",
-        "EWKWPlus2Jets_WToLNu_M-50_TuneCP5_withDipoleRecoil_13TeV",
+        "EWKZ2Jets_ZToLL_M-50_TuneCP5_withDipoleRecoil_13TeV",
+        "EWKZ2Jets_ZToNuNu_M-50_TuneCP5_withDipoleRecoil_13TeV",
+        "EWKZ2Jets_ZToQQ_dipoleRecoilOn_TuneCP5_13TeV",
+        "WWJJToLNuLNu_EWK_noTop_TuneCP5_13TeV",
     ],
     "VV" : [
-        "ZZTo4Q_5f_TuneCP5_13TeV",
-        "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV",
-        "ZZJJTo4L_TuneCP5_13TeV",
-        "GluGluToContinToZZTo2e2tau_TuneCP5_13TeV",
-        "GluGluToContinToZZTo4tau_TuneCP5_13TeV",
-        "GluGluToContinToZZTo2mu2tau_TuneCP5_13TeV",
-        "GluGluToContinToZZTo4mu_TuneCP5_13TeV",
         "GluGluToContinToZZTo2e2mu_TuneCP5_13TeV",
+        "GluGluToContinToZZTo2e2tau_TuneCP5_13TeV",
+        "GluGluToContinToZZTo2mu2tau_TuneCP5_13TeV",
         "GluGluToContinToZZTo4e_TuneCP5_13TeV",
-        "WW_TuneCP5_13TeV",
-        "WWTo2L2Nu_TuneCP5_13TeV",
-        "WWTo1L1Nu2Q_4f_TuneCP5_13TeV",
-        "WWTo4Q_4f_TuneCP5_13TeV",
+        "GluGluToContinToZZTo4mu_TuneCP5_13TeV",
+        "GluGluToContinToZZTo4tau_TuneCP5_13TeV",
+        "GluGluZH_HToWWTo2L2Nu_TuneCP5_13TeV",
+        "GluGluZH_HToWWTo2L2Nu_M-125_TuneCP5_13TeV",
         "WZ_TuneCP5_13TeV",
-        "WZTo1L3Nu_4f_TuneCP5_13TeV",
-        "WZTo3LNu_TuneCP5_13TeV",
-        "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV",
+        "WZJJ_EWK_InclusivePolarization_TuneCP5_13TeV",
         "WZTo1L1Nu2Q_4f_TuneCP5_13TeV",
+        "WZTo1L3Nu_4f_TuneCP5_13TeV",
+        "WZTo2Q2L_mllmin4p0_TuneCP5_13TeV",
+        "WZTo3LNu_TuneCP5_13TeV",
+        "WW_TuneCP5_13TeV",
         "ZZ_TuneCP5_13TeV",
-        "ZZTo4L_M-1toInf_TuneCP5_13TeV",
-        "ZZTo2L2Nu_TuneCP5_13TeV",
-        #"ZZTo2Nu2Q_5f_TuneCP5_13TeV", # Weirdly crashes the processor
+        "WWTo4Q_4f_TuneCP5_13TeV",
+        "WWTo1L1Nu2Q_4f_TuneCP5_13TeV",
+        "WWTo2L2Nu_TuneCP5_13TeV",
         "GluGluHToZZTo4L",
+        "ZZJJTo4L_TuneCP5_13TeV",
+        "ZZTo2Nu2Q_5f_TuneCP5_13TeV",
+        "ZZTo4Q_5f_TuneCP5_13TeV",
+        "ZZJJTo4L_EWKnotop_TuneCP5_13TeV",
+        "ZZTo2L2Nu_TuneCP5_13TeV",
+        "ZZTo2Q2L_mllmin4p0_TuneCP5_13TeV",
+        "ZZTo4L_M-1toInf_TuneCP5_13TeV",
     ],
     "ewkVV" : [
         "SSWW",
-        "WZJJ_EWK_InclusivePolarization_TuneCP5_13TeV",
-        "WWJJToLNuLNu_EWK_noTop_TuneCP5_13TeV",
     ],
     "VH" : [
-        "ZH_HToBB_ZToBB_M-125_TuneCP5_13TeV",
-        "ZH_HToBB_ZToQQ_M-125_TuneCP5_13TeV",
-        "ZH_HToBB_ZToNuNu_M-125_TuneCP5_13TeV",
-        "ZH_HToBB_ZToLL_M-125_TuneCP5_13TeV",
-        "ggZH_HToBB_ZToBB_M-125_TuneCP5_13TeV",
-        "ggZH_HToBB_ZToQQ_M-125_TuneCP5_13TeV",
-        "ggZH_HToBB_ZToLL_M-125_TuneCP5_13TeV",
-        "ggZH_HToBB_ZToNuNu_M-125_TuneCP5_13TeV",
-        "GluGluZH_HToWWTo2L2Nu_M-125_TuneCP5_13TeV",
-        "HZJ_HToWWTo2L2Nu_ZTo2L_M-125_TuneCP5_13TeV",
-        "VHToNonbb_M125_TuneCP5_13TeV",
-        "WminusH_HToBB_WToLNu_M-125_TuneCP5_13TeV",
-        #"WminusH_HToBB_WToQQ_M-125_TuneCP5_13TeV", # Missing UL16APV
-        #"WplusH_HToBB_WToQQ_M-125_TuneCP5_13TeV", # Missing UL16APV
-        "WplusH_HToBB_WToLNu_M-125_TuneCP5_13TeV",
         "VBFWH_HToBB_WToLNu_M-125_dipoleRecoilOn_TuneCP5_13TeV",
+        "VHToNonbb_M125_TuneCP5_13TeV",
+        "ggZH_HToBB_ZToLL_M-125_TuneCP5_13TeV",
+        "ggZH_HToBB_ZToBB_M-125_TuneCP5_13TeV",
+        "ggZH_HToBB_ZToNuNu_M-125_TuneCP5_13TeV",
+        "ggZH_HToBB_ZToQQ_M-125_TuneCP5_13TeV",
+        "ZH_HToBB_ZToLL_M-125_TuneCP5_13TeV",
+        "ZH_HToBB_ZToBB_M-125_TuneCP5_13TeV",
+        "ZH_HToBB_ZToNuNu_M-125_TuneCP5_13TeV",
+        "ZH_HToBB_ZToQQ_M-125_TuneCP5_13TeV",
+        "HZJ_HToWWTo2L2Nu_ZTo2L_M-125_TuneCP5_13TeV",
     ],
     "VVV" : [
-        "ZZZ_TuneCP5_13TeV",
-        "WZZ_TuneCP5_13TeV",
-        "WWZ_4F_TuneCP5_13TeV",
         "WWW_4F_TuneCP5_13TeV",
+        "WWZ_4F_TuneCP5_13TeV",
+        "WZZ_TuneCP5_13TeV",
+        "ZZZ_TuneCP5_13TeV",
     ],
 
 }
@@ -175,24 +180,24 @@ CAT_LST = [
     #"just2lep",
     #"just3lep",
 
-    #### 2l OS SF 1FJ ###
-    #"2l",
-    #"2lOS",
-    #"2lOSSF",
-    #"2lOSSF_1fj",
+    ### 2l OS SF 1FJ ###
+    "2l",
+    "2lOS",
+    "2lOSSF",
+    "2lOSSF_1fj",
     "2lOSSF_1fjx",
-    #"2lOSSF_1fjx_onZ",
-    #"2lOSSF_1fjx_onZ_HFJ",
-    #"2lOSSF_1fjx_onZ_HFJtag",
-    #"2lOSSF_1fjx_onZ_HFJtag_nj2",
-    #"2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
+    "2lOSSF_1fjx_onZ",
+    "2lOSSF_1fjx_onZ_HFJ",
+    "2lOSSF_1fjx_onZ_HFJtag",
+    "2lOSSF_1fjx_onZ_HFJtag_nj2",
+    "2lOSSF_1fjx_onZ_HFJtag_nj2_mjj600",
 
     ### 3l ###
     "3l",
-    #"3l_2j_mjj600",
-    #"3l_2j_mjj600_ht350"
-    #"3l_2j_mjj600_noSFOS",
-    #"3l_2j_mjj600_ch3",
+    "3l_2j_mjj600",
+    "3l_2j_mjj600_ht350"
+    "3l_2j_mjj600_noSFOS",
+    "3l_2j_mjj600_ch3",
 ]
 
 
@@ -215,7 +220,8 @@ def get_yields_per_cat(histo_dict,var_name,grp_dict,year_name_lst_to_prepend):
     out_dict = {}
 
     # Get the initial grouping dict
-    grouping_dict = append_years(grp_dict,year_name_lst_to_prepend)
+    #grouping_dict = append_years(grp_dict,year_name_lst_to_prepend) # For fromnano
+    grouping_dict = copy.deepcopy(grp_dict)
 
     # Get list of all of the backgrounds together
     bkg_lst = []
@@ -230,7 +236,8 @@ def get_yields_per_cat(histo_dict,var_name,grp_dict,year_name_lst_to_prepend):
     # Loop over cats and fill dict of sig and bkg
     for cat in CAT_LST:
         out_dict[cat] = {}
-        histo_base = histo_dict[var_name][{"systematic":"nominal", "category":cat}]
+        #histo_base = histo_dict[var_name][{"systematic":"nominal", "category":cat}] # For fromnano
+        histo_base = histo_dict[var_name][{"systematic":"nominal", "category":cat, "year": sum}]
 
         # Get values per proc
         for group_name,group_lst in groups_to_get_yields_for_dict.items():
@@ -537,7 +544,8 @@ def make_plots(histo_dict,grp_dict,year_name_lst_to_prepend):
 
     #cat_lst = ["exactly1lep_exactly1fj", "exactly1lep_exactly1fj550", "exactly1lep_exactly1fj550_2j", "exactly1lep_exactly1fj_2j"]
 
-    grouping_dict = append_years(grp_dict,year_name_lst_to_prepend)
+    #grouping_dict = append_years(grp_dict,year_name_lst_to_prepend) # For fromnano
+    grouping_dict = copy.deepcopy(grp_dict)
 
     sample_group_names_lst_mc = []
     sample_group_names_lst_bkg = []


### PR DESCRIPTION
Update to the processor that takes RDF inputs to handle the current (March, 2026) RDF outputs. 

Some updates to histogram making script for naming and such.

Note that the outputs of RDF are v15 so some things change from the previous fromnano (e.g., electron pt is different, the background sample list is different, etc). 

Note that to the coffea nano events schema (`coffea/nanoevents/schemas/nanoaod.py`) added to `mixins`:
```
"jet": "PtEtaPhiMCollection",
"fatjet": "PtEtaPhiMCollection",
"spanet" : "spanet", 
```